### PR TITLE
修复Linux服务模式失效,修改文本

### DIFF
--- a/native/stelliberty_service/src/lib.rs
+++ b/native/stelliberty_service/src/lib.rs
@@ -64,7 +64,7 @@ pub fn print_privilege_error() {
 
     #[cfg(not(windows))]
     {
-        eprintln!("请使用 sudo 运行:");
+        eprintln!("请手动使用 sudo 运行:");
         if let Some(ref path) = binary_path {
             eprintln!("sudo {} install", path.display());
         } else {

--- a/native/stelliberty_service/src/service/installer.rs
+++ b/native/stelliberty_service/src/service/installer.rs
@@ -268,6 +268,7 @@ After=network.target
 
 [Service]
 Type=simple
+UMask=0000
 ExecStart={binary_path}
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
使手动安装服务模式后可以启用虚拟网卡
<img width="1074" height="205" alt="image" src="https://github.com/user-attachments/assets/174311b7-3936-40ab-8ad2-34451dff1dd5" />
<img width="952" height="712" alt="image" src="https://github.com/user-attachments/assets/23d29c72-8fb4-4a1d-9ae5-40cb2d4a5e9b" />
