### PR TITLE
release: promote v2.0.2 to stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,9 @@
-- Beta releases can now be detected when the update channel is set to Beta.
-- Subscription and override updates now report individual results and batch success or failure counts.
+- Proxy Provider nodes remain visible, selectable, and available for delay testing with the latest mihomo core.
+- Individual and batch delay tests can run together without losing completed results.
+- Long proxy node tooltips now wrap within a limited height.
 
 ---
 
-- 更新通道设为测试版后，现在可以检测测试版发布。
-- 订阅和覆写更新现在会反馈单项结果，以及批量更新的成功和失败数量。
+- 使用最新版 mihomo 核心时，Proxy Provider 节点仍可正常显示、选择并进行延迟测试。
+- 单节点与批量延迟测试现在可以同时运行，已完成的结果不会丢失。
+- 较长的代理节点提示文字现在会在限定高度内换行显示。

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -38,6 +38,34 @@ jobs:
         shell: bash
         run: test "${{ github.ref }}" = 'refs/heads/beta'
 
+  detect-beta-build-changes:
+    name: Detect beta build changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/beta'
+    runs-on: ubuntu-22.04
+    outputs:
+      should_build: ${{ steps.changes.outputs.should_build }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect C# and Rust source changes
+        id: changes
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}" | grep -Eq '\.(cs|rs)$'; then
+            echo 'should_build=true' >> "$GITHUB_OUTPUT"
+            echo 'C# or Rust source changes require a beta build.'
+          else
+            echo 'should_build=false' >> "$GITHUB_OUTPUT"
+            echo 'No C# or Rust source changes; beta build is skipped.'
+          fi
+
   code-quality:
     name: Trigger code quality
     if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/beta'
@@ -52,13 +80,16 @@ jobs:
 
   beta-build:
     name: Trigger beta build
-    needs: [code-quality, stability-verification]
+    needs: [detect-beta-build-changes, code-quality, stability-verification]
     if: >-
       ${{
+        always() &&
+        needs.detect-beta-build-changes.result == 'success' &&
+        needs.detect-beta-build-changes.outputs.should_build == 'true' &&
         needs.code-quality.result == 'success' &&
         needs.stability-verification.result == 'success' &&
         github.ref == 'refs/heads/beta' &&
-        (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        github.event_name == 'push'
       }}
     uses: ./.github/workflows/build-beta.yml
     secrets: inherit

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect C# and Rust source changes
+      - name: Detect product changes
         id: changes
         shell: bash
         env:
@@ -58,12 +58,24 @@ jobs:
           AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if git diff --name-only "${BEFORE_SHA}" "${AFTER_SHA}" | grep -Eq '\.(cs|rs)$'; then
-            echo 'should_build=true' >> "$GITHUB_OUTPUT"
-            echo 'C# or Rust source changes require a beta build.'
+          base_tag="$(git tag --merged "${AFTER_SHA}" --list 'v[0-9]*' --sort=-version:refname | sed -n '1p')"
+          base_ref="${base_tag:-${BEFORE_SHA}}"
+          should_build=false
+
+          while IFS= read -r path; do
+            case "${path}" in
+              *.cs|*.rs|*.axaml|*.csproj|Directory.Build.props|Cargo.toml)
+                should_build=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${base_ref}" "${AFTER_SHA}")
+
+          echo "should_build=${should_build}" >> "$GITHUB_OUTPUT"
+          if [ "${should_build}" = true ]; then
+            echo "Product changes since ${base_ref} require a beta build."
           else
-            echo 'should_build=false' >> "$GITHUB_OUTPUT"
-            echo 'No C# or Rust source changes; beta build is skipped.'
+            echo "No product changes since ${base_ref}; beta build is skipped."
           fi
 
   code-quality:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.1</AppVersion>
+    <AppVersion>2.0.2</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/hub/Cargo.toml
+++ b/native/hub/Cargo.toml
@@ -20,7 +20,7 @@ tracing = "^0.1.44"
 tracing-subscriber = { version = "^0.3.23", features = ["fmt", "env-filter"] }
 interprocess = { version = "^2.4.2", features = ["tokio"] }
 async-trait = "^0.1.89"
-tokio-tungstenite = "^0.28"
+tokio-tungstenite = "^0.30"
 futures-util = "^0.3"
 age = { version = "^0.11.3", features = ["armor"] }
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -22,6 +22,7 @@ from build_support.help import MultilineHelpFormatter
 ROOT = Path(__file__).resolve().parents[1]
 RUST_WORKSPACE = ROOT / "Cargo.toml"
 CSHARP_TESTS: list[tuple[str, Path, str]] = [
+    ("infrastructure", ROOT / "tests" / "Stelliberty.Infrastructure.Tests" / "Stelliberty.Infrastructure.Tests.csproj", "Infrastructure integrations: core REST responses, remote downloads, and platform behavior"),
     ("proxy-selection", ROOT / "tests" / "Stelliberty.ProxySelection.Tests" / "Stelliberty.ProxySelection.Tests.csproj", "Proxy selection semantics: default nodes, fixed groups, local persistence, external sync, and outbound mode"),
     ("proxy-page", ROOT / "tests" / "Stelliberty.ProxyPage.Tests" / "Stelliberty.ProxyPage.Tests.csproj", "Proxy page interactions: visible groups, node switching, search, sorting, delay tests, and controller sync"),
     ("home-state", ROOT / "tests" / "Stelliberty.Home.Tests" / "Stelliberty.Home.Tests.csproj", "Home state: system proxy, TUN permissions, outbound mode, runtime refresh, and service mode"),

--- a/src/Stelliberty.Application/Proxies/IProviderProxyDelayTester.cs
+++ b/src/Stelliberty.Application/Proxies/IProviderProxyDelayTester.cs
@@ -1,0 +1,9 @@
+namespace Stelliberty.Application.Proxies;
+
+public interface IProviderProxyDelayTester : IProxyDelayTester
+{
+    Task<int> TestProviderDelayAsync(
+        string providerName,
+        string proxyName,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Stelliberty.Application/Proxies/ProxyDelayService.cs
+++ b/src/Stelliberty.Application/Proxies/ProxyDelayService.cs
@@ -7,8 +7,9 @@ namespace Stelliberty.Application.Proxies;
 
 public sealed class ProxyDelayService(IProxyDelayTester tester)
 {
-    // 限制并发，避免 mihomo 延迟测试超出核心承载。
+    // 所有测速共享并发预算，避免单测与批测叠加超出核心承载。
     private const int DelayTestConcurrency = 15;
+    private readonly SemaphoreSlim _delayTestSemaphore = new(DelayTestConcurrency);
 
     public async Task<ProxyDelayResult> TestNodeAsync(ProxyConfig config, string proxyName, CancellationToken cancellationToken = default)
     {
@@ -18,7 +19,7 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var delay = await tester.TestDelayAsync(proxyName, cancellationToken);
+        var delay = await TestDelayAsync(proxyName, cancellationToken);
         if (delay >= 0)
         {
             AppLogger.Info($"Proxy delay test completed: proxy={proxyName} delay={delay}ms elapsed={stopwatch.Elapsed.TotalMilliseconds:0}ms");
@@ -36,31 +37,54 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
     }
 
     public Task<ProxyDelayResult> TestGroupAsync(ProxyConfig config, string groupName, CancellationToken cancellationToken = default)
-        => TestGroupAsync(config, groupName, null, cancellationToken);
+        => TestGroupAsync(config, groupName, [], null, cancellationToken);
 
-    public Task<ProxyDelayResult> TestGroupAsync(ProxyConfig config, string groupName, IProgress<ProxyDelayProgress>? progress, CancellationToken cancellationToken = default)
+    public Task<ProxyDelayResult> TestGroupAsync(
+        ProxyConfig config,
+        string groupName,
+        IProgress<ProxyDelayProgress>? progress,
+        CancellationToken cancellationToken = default)
+        => TestGroupAsync(config, groupName, [], progress, cancellationToken);
+
+    public Task<ProxyDelayResult> TestGroupAsync(
+        ProxyConfig config,
+        string groupName,
+        IReadOnlyCollection<string> excludedProxyNames,
+        IProgress<ProxyDelayProgress>? progress,
+        CancellationToken cancellationToken = default)
     {
         var group = config.Groups.FirstOrDefault(item => item.Name == groupName)
             ?? throw new InvalidOperationException($"Proxy group not found: {groupName}");
-        return TestNodesAsync(config, group.All, $"group={group.Name}", progress, cancellationToken);
+        return TestNodesAsync(config, group.All, excludedProxyNames, $"group={group.Name}", progress, cancellationToken);
     }
 
     public Task<ProxyDelayResult> TestAllAsync(ProxyConfig config, CancellationToken cancellationToken = default)
-        => TestAllAsync(config, null, cancellationToken);
+        => TestAllAsync(config, [], null, cancellationToken);
 
-    public Task<ProxyDelayResult> TestAllAsync(ProxyConfig config, IProgress<ProxyDelayProgress>? progress, CancellationToken cancellationToken = default)
+    public Task<ProxyDelayResult> TestAllAsync(
+        ProxyConfig config,
+        IProgress<ProxyDelayProgress>? progress,
+        CancellationToken cancellationToken = default)
+        => TestAllAsync(config, [], progress, cancellationToken);
+
+    public Task<ProxyDelayResult> TestAllAsync(
+        ProxyConfig config,
+        IReadOnlyCollection<string> excludedProxyNames,
+        IProgress<ProxyDelayProgress>? progress,
+        CancellationToken cancellationToken = default)
     {
         var proxyNames = config.Groups
             .SelectMany(group => group.All)
             .Distinct(StringComparer.Ordinal)
             .ToList();
-        return TestNodesAsync(config, proxyNames, "scope=all", progress, cancellationToken);
+        return TestNodesAsync(config, proxyNames, excludedProxyNames, "scope=all", progress, cancellationToken);
     }
 
     // 并发测试结束后再合并，避免工作任务修改快照。
     private async Task<ProxyDelayResult> TestNodesAsync(
         ProxyConfig config,
         IReadOnlyList<string> proxyNames,
+        IReadOnlyCollection<string> excludedProxyNames,
         string scope,
         IProgress<ProxyDelayProgress>? progress,
         CancellationToken cancellationToken)
@@ -68,6 +92,7 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         var stopwatch = Stopwatch.StartNew();
         var targets = new List<string>();
         var skipped = new List<string>();
+        var excluded = excludedProxyNames.ToHashSet(StringComparer.Ordinal);
         var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var proxyName in proxyNames)
         {
@@ -76,7 +101,11 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
                 continue;
             }
 
-            if (ProxyConfigSelectionNormalizer.HasEntry(config, proxyName))
+            if (excluded.Contains(proxyName))
+            {
+                skipped.Add(proxyName);
+            }
+            else if (ProxyConfigSelectionNormalizer.HasEntry(config, proxyName))
             {
                 targets.Add(proxyName);
             }
@@ -87,20 +116,11 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         }
 
         var delays = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
-        using var semaphore = new SemaphoreSlim(DelayTestConcurrency);
         var tasks = targets.Select(async proxyName =>
         {
-            await semaphore.WaitAsync(cancellationToken);
-            try
-            {
-                var delay = await tester.TestDelayAsync(proxyName, cancellationToken);
-                delays[proxyName] = delay;
-                progress?.Report(new ProxyDelayProgress(proxyName, delay));
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            var delay = await TestDelayAsync(proxyName, cancellationToken);
+            delays[proxyName] = delay;
+            progress?.Report(new ProxyDelayProgress(proxyName, delay));
         });
         await Task.WhenAll(tasks);
         cancellationToken.ThrowIfCancellationRequested();
@@ -122,6 +142,19 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
 
         LogBatchResult(scope, targets.Count, tested.Count - failed.Count, failed.Count, skipped.Count, stopwatch.Elapsed);
         return new ProxyDelayResult(config.WithEntryDelays(testedDelays), tested, skipped, failed);
+    }
+
+    private async Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken)
+    {
+        await _delayTestSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            return await tester.TestDelayAsync(proxyName, cancellationToken);
+        }
+        finally
+        {
+            _delayTestSemaphore.Release();
+        }
     }
 
     private static void LogBatchResult(string scope, int total, int succeeded, int failed, int skipped, TimeSpan elapsed)

--- a/src/Stelliberty.Application/Proxies/ProxyDelayService.cs
+++ b/src/Stelliberty.Application/Proxies/ProxyDelayService.cs
@@ -19,7 +19,7 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var delay = await TestDelayAsync(proxyName, cancellationToken);
+        var delay = await TestDelayAsync(config, proxyName, cancellationToken);
         if (delay >= 0)
         {
             AppLogger.Info($"Proxy delay test completed: proxy={proxyName} delay={delay}ms elapsed={stopwatch.Elapsed.TotalMilliseconds:0}ms");
@@ -118,7 +118,7 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         var delays = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
         var tasks = targets.Select(async proxyName =>
         {
-            var delay = await TestDelayAsync(proxyName, cancellationToken);
+            var delay = await TestDelayAsync(config, proxyName, cancellationToken);
             delays[proxyName] = delay;
             progress?.Report(new ProxyDelayProgress(proxyName, delay));
         });
@@ -144,11 +144,18 @@ public sealed class ProxyDelayService(IProxyDelayTester tester)
         return new ProxyDelayResult(config.WithEntryDelays(testedDelays), tested, skipped, failed);
     }
 
-    private async Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken)
+    private async Task<int> TestDelayAsync(ProxyConfig config, string proxyName, CancellationToken cancellationToken)
     {
         await _delayTestSemaphore.WaitAsync(cancellationToken);
         try
         {
+            if (tester is IProviderProxyDelayTester providerTester
+                && config.Nodes.TryGetValue(proxyName, out var node)
+                && !string.IsNullOrWhiteSpace(node.ProviderName))
+            {
+                return await providerTester.TestProviderDelayAsync(node.ProviderName, proxyName, cancellationToken);
+            }
+
             return await tester.TestDelayAsync(proxyName, cancellationToken);
         }
         finally

--- a/src/Stelliberty.Application/Proxies/ProxyRuntimeSnapshot.cs
+++ b/src/Stelliberty.Application/Proxies/ProxyRuntimeSnapshot.cs
@@ -9,4 +9,5 @@ public sealed record ProxyRuntimeEntry(
     string? Now,
     string? Fixed,
     IReadOnlyList<string> All,
-    bool IsHidden);
+    bool IsHidden,
+    string? ProviderName = null);

--- a/src/Stelliberty.Application/Subscriptions/SubscriptionProviderCatalog.cs
+++ b/src/Stelliberty.Application/Subscriptions/SubscriptionProviderCatalog.cs
@@ -45,6 +45,17 @@ public sealed class SubscriptionProviderCatalog(
         return new SubscriptionProviderSyncResult([provider.Name], []);
     }
 
+    public async Task ReloadProviderAsync(string providerName, CancellationToken cancellationToken = default)
+    {
+        var provider = providers.FirstOrDefault(item => item.Name == providerName);
+        if (provider is null || syncer is null)
+        {
+            return;
+        }
+
+        await syncer.SyncAsync(provider, cancellationToken);
+    }
+
     public async Task<SubscriptionProviderSyncResult> SyncAllAsync(CancellationToken cancellationToken = default)
     {
         var synced = new List<string>();

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -133,7 +133,7 @@ public sealed partial class App : Avalonia.Application
                 new SubscriptionProviderParser(),
                 coreProviderClient,
                 coreProviderClient);
-            ISubscriptionProviderUploader subscriptionProviderUploader = new FileSubscriptionProviderUploader(platformDirectories.AppDataDirectory);
+            ISubscriptionProviderUploader subscriptionProviderUploader = new FileSubscriptionProviderUploader(platformDirectories.CoreDirectory);
             ISubscriptionFileOpener subscriptionFileOpener = new DesktopSubscriptionFileOpener(subscriptionStore.GetContentPath);
             IOverrideFileOpener overrideFileOpener = new DesktopOverrideFileOpener(overrideStore.GetContentPath);
             var clipboardWriter = new DesktopClipboardWriter(desktop);

--- a/src/Stelliberty.Desktop/Styles/ProxyStyles.axaml
+++ b/src/Stelliberty.Desktop/Styles/ProxyStyles.axaml
@@ -126,7 +126,8 @@
 
   <Style Selector="TextBlock.proxy-node-tooltip">
     <Setter Property="MaxWidth" Value="520" />
-    <Setter Property="TextWrapping" Value="NoWrap" />
-    <Setter Property="TextTrimming" Value="None" />
+    <Setter Property="MaxLines" Value="3" />
+    <Setter Property="TextWrapping" Value="Wrap" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
   </Style>
 </Styles>

--- a/src/Stelliberty.Desktop/Views/ProxyView.axaml
+++ b/src/Stelliberty.Desktop/Views/ProxyView.axaml
@@ -74,7 +74,7 @@
             <Button Classes="toolbar-icon"
                     AutomationProperties.AutomationId="Proxy.TestGroupDelaysButton"
                     Command="{Binding TestCurrentGroupDelaysCommand}"
-                    IsEnabled="{Binding !IsDelayTesting}"
+                    IsEnabled="{Binding !IsBatchDelayTesting}"
                     ToolTip.Tip="{loc:Loc Proxy.Tooltip.TestCurrentGroup}">
               <iconPacks:PackIconMingCuteIcons Classes="icon" Width="15" Height="15" Kind="ChartBarFill" />
             </Button>

--- a/src/Stelliberty.Domain/Proxies/ProxyNode.cs
+++ b/src/Stelliberty.Domain/Proxies/ProxyNode.cs
@@ -5,4 +5,5 @@ public sealed record ProxyNode(
     string Type,
     int? Delay = null,
     string? Server = null,
-    int? Port = null);
+    int? Port = null,
+    string? ProviderName = null);

--- a/src/Stelliberty.Infrastructure/Proxies/MihomoApiProxyConfigProvider.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/MihomoApiProxyConfigProvider.cs
@@ -27,7 +27,7 @@ public sealed class MihomoApiProxyConfigProvider(
         foreach (var entry in snapshot.Entries)
         {
             // 核心 history 跨订阅和进程复用，代理页只显示当前会话的延迟测试结果。
-            nodes[entry.Name] = new ProxyNode(entry.Name, entry.Type);
+            nodes[entry.Name] = new ProxyNode(entry.Name, entry.Type, ProviderName: entry.ProviderName);
 
             // mihomo 可能给分组返回未知类型；all[] 仍表示分组。
             if (GroupTypes.Contains(entry.Type) || entry.All.Count > 0)

--- a/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
@@ -141,27 +141,18 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
     {
         try
         {
-            using var response = await _client.GetAsync("proxies", cancellationToken);
-            response.EnsureSuccessStatusCode();
-            var json = await response.Content.ReadAsStringAsync(cancellationToken);
-            using var doc = JsonDocument.Parse(json);
-            if (!doc.RootElement.TryGetProperty("proxies", out var proxies) || proxies.ValueKind != JsonValueKind.Object)
-            {
-                return new ProxyRuntimeSnapshot([]);
-            }
-            var entries = new List<ProxyRuntimeEntry>();
-            foreach (var prop in proxies.EnumerateObject())
-            {
-                var node = prop.Value;
-                var type = node.TryGetProperty("type", out var t) ? t.GetString() ?? string.Empty : string.Empty;
-                var now = node.TryGetProperty("now", out var n) && n.ValueKind == JsonValueKind.String ? n.GetString() : null;
-                var fixedSelection = node.TryGetProperty("fixed", out var f) && f.ValueKind == JsonValueKind.String ? f.GetString() : null;
-                var all = node.TryGetProperty("all", out var a) && a.ValueKind == JsonValueKind.Array
-                    ? a.EnumerateArray().Select(x => x.GetString() ?? string.Empty).ToList()
-                    : new List<string>();
-                var hidden = node.TryGetProperty("hidden", out var h) && h.ValueKind == JsonValueKind.True;
-                entries.Add(new ProxyRuntimeEntry(prop.Name, type, now, fixedSelection, all, hidden));
-            }
+            using var proxiesResponse = await _client.GetAsync("proxies", cancellationToken);
+            proxiesResponse.EnsureSuccessStatusCode();
+            var proxiesJson = await proxiesResponse.Content.ReadAsStringAsync(cancellationToken);
+            using var proxiesDocument = JsonDocument.Parse(proxiesJson);
+            var entriesByName = ParseProxyEntries(proxiesDocument.RootElement);
+
+            using var providersResponse = await _client.GetAsync("providers/proxies", cancellationToken);
+            providersResponse.EnsureSuccessStatusCode();
+            var providersJson = await providersResponse.Content.ReadAsStringAsync(cancellationToken);
+            using var providersDocument = JsonDocument.Parse(providersJson);
+            MergeProviderEntries(entriesByName, providersDocument.RootElement);
+            var entries = entriesByName.Values.ToList();
 
             // /proxies 键顺序不是订阅顺序；GLOBAL.all 才是。
             var global = entries.FirstOrDefault(entry => string.Equals(entry.Name, "GLOBAL", StringComparison.Ordinal));
@@ -180,11 +171,76 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
 
             return new ProxyRuntimeSnapshot(entries);
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException)
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or IOException
+            || ex is TaskCanceledException && !cancellationToken.IsCancellationRequested)
         {
             AppLogger.Warning($"Core proxy list read failed: {ex.Message}");
             return new ProxyRuntimeSnapshot([]);
         }
+    }
+
+    private static Dictionary<string, ProxyRuntimeEntry> ParseProxyEntries(JsonElement root)
+    {
+        var entries = new Dictionary<string, ProxyRuntimeEntry>(StringComparer.Ordinal);
+        if (!root.TryGetProperty("proxies", out var proxies) || proxies.ValueKind != JsonValueKind.Object)
+        {
+            return entries;
+        }
+
+        foreach (var proxy in proxies.EnumerateObject())
+        {
+            entries[proxy.Name] = ParseProxyEntry(proxy.Name, proxy.Value);
+        }
+
+        return entries;
+    }
+
+    private static void MergeProviderEntries(
+        Dictionary<string, ProxyRuntimeEntry> entries,
+        JsonElement root)
+    {
+        if (!root.TryGetProperty("providers", out var providers) || providers.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        foreach (var provider in providers.EnumerateObject())
+        {
+            if (!provider.Value.TryGetProperty("proxies", out var proxies) || proxies.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var proxy in proxies.EnumerateArray())
+            {
+                if (proxy.ValueKind != JsonValueKind.Object
+                    || !proxy.TryGetProperty("name", out var nameNode)
+                    || nameNode.ValueKind != JsonValueKind.String
+                    || string.IsNullOrEmpty(nameNode.GetString()))
+                {
+                    continue;
+                }
+
+                var name = nameNode.GetString()!;
+                entries.TryAdd(name, ParseProxyEntry(name, proxy, provider.Name));
+            }
+        }
+    }
+
+    private static ProxyRuntimeEntry ParseProxyEntry(string name, JsonElement node, string? providerName = null)
+    {
+        var type = node.TryGetProperty("type", out var typeNode) ? typeNode.GetString() ?? string.Empty : string.Empty;
+        var now = node.TryGetProperty("now", out var nowNode) && nowNode.ValueKind == JsonValueKind.String
+            ? nowNode.GetString()
+            : null;
+        var fixedSelection = node.TryGetProperty("fixed", out var fixedNode) && fixedNode.ValueKind == JsonValueKind.String
+            ? fixedNode.GetString()
+            : null;
+        var all = node.TryGetProperty("all", out var allNode) && allNode.ValueKind == JsonValueKind.Array
+            ? allNode.EnumerateArray().Select(item => item.GetString() ?? string.Empty).ToList()
+            : [];
+        var isHidden = node.TryGetProperty("hidden", out var hiddenNode) && hiddenNode.ValueKind == JsonValueKind.True;
+        return new ProxyRuntimeEntry(name, type, now, fixedSelection, all, isHidden, providerName);
     }
 
     public async Task<OutboundMode?> GetOutboundModeAsync(CancellationToken cancellationToken = default)

--- a/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyDelayTester.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyDelayTester.cs
@@ -4,7 +4,7 @@ using Stelliberty.Application.Proxies;
 
 namespace Stelliberty.Infrastructure.Proxies;
 
-public sealed class PipeCoreProxyDelayTester : IProxyDelayTester, IDisposable
+public sealed class PipeCoreProxyDelayTester : IProviderProxyDelayTester, IDisposable
 {
     private readonly HttpClient _client;
     private readonly Func<string> _testUrlFactory;
@@ -39,10 +39,25 @@ public sealed class PipeCoreProxyDelayTester : IProxyDelayTester, IDisposable
 
     public async Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken = default)
     {
+        var path = $"proxies/{Uri.EscapeDataString(proxyName)}/delay";
+        return await SendDelayRequestAsync(path, cancellationToken);
+    }
+
+    public async Task<int> TestProviderDelayAsync(
+        string providerName,
+        string proxyName,
+        CancellationToken cancellationToken = default)
+    {
+        var path = $"providers/proxies/{Uri.EscapeDataString(providerName)}/{Uri.EscapeDataString(proxyName)}/healthcheck";
+        return await SendDelayRequestAsync(path, cancellationToken);
+    }
+
+    private async Task<int> SendDelayRequestAsync(string proxyPath, CancellationToken cancellationToken)
+    {
         try
         {
             var testUrl = _testUrlFactory();
-            var path = $"proxies/{Uri.EscapeDataString(proxyName)}/delay?timeout={_timeoutMilliseconds}&url={Uri.EscapeDataString(testUrl)}";
+            var path = $"{proxyPath}?timeout={_timeoutMilliseconds}&url={Uri.EscapeDataString(testUrl)}";
             using var response = await _client.GetAsync(path, cancellationToken);
             if (!response.IsSuccessStatusCode)
             {
@@ -53,7 +68,8 @@ public sealed class PipeCoreProxyDelayTester : IProxyDelayTester, IDisposable
             var payload = await JsonSerializer.DeserializeAsync<DelayPayload>(stream, cancellationToken: cancellationToken);
             return NormalizeDelay(payload?.Delay ?? -1);
         }
-        catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException or JsonException or IOException)
+        catch (Exception exception) when (exception is HttpRequestException or JsonException or IOException
+            || exception is TaskCanceledException && !cancellationToken.IsCancellationRequested)
         {
             return -1;
         }

--- a/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionProviderUploader.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionProviderUploader.cs
@@ -20,9 +20,12 @@ public sealed class FileSubscriptionProviderUploader(string providerRootDirector
 
         var targetPath = ResolveProviderPath(provider.Path);
         Directory.CreateDirectory(Path.GetDirectoryName(targetPath) ?? providerRootDirectory);
-        await using var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 81920, useAsync: true);
-        await using var target = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
-        await source.CopyToAsync(target, cancellationToken);
+        await using (var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 81920, useAsync: true))
+        await using (var target = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true))
+        {
+            await source.CopyToAsync(target, cancellationToken);
+        }
+
         AppLogger.Info($"File Provider upload completed: {provider.Name}");
         return SubscriptionProviderUploadResult.Uploaded();
     }

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -45,7 +45,12 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private string? _lastSelectedNodeName;
     private string? _locatedNodeName;
     private ProxyChangeRequest? _lastChangeRequest;
-    private CancellationTokenSource? _delayTestCancellation;
+    private CancellationTokenSource? _batchDelayTestCancellation;
+    private CancellationTokenSource? _singleDelayTestCancellation;
+    private string? _singleDelayTestingNodeName;
+    private readonly HashSet<string> _batchDelayTargetNodeNames = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _batchDelayTestingNodeNames = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _batchDelayResults = new(StringComparer.Ordinal);
     private bool _shouldCloseConnectionsAfterSelection;
     private bool _shouldChangeCoreOnSelection = true;
     private bool _shouldTestDelaysThroughService = true;
@@ -503,12 +508,13 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public async Task TestNodeDelayAsync(string? nodeName)
     {
-        if (string.IsNullOrWhiteSpace(nodeName))
+        if (string.IsNullOrWhiteSpace(nodeName)
+            || _batchDelayTargetNodeNames.Contains(nodeName))
         {
             return;
         }
 
-        var cancellation = BeginDelayTest([nodeName], isBatch: false);
+        var cancellation = BeginSingleDelayTest(nodeName);
         try
         {
             var configVersion = _configVersion;
@@ -524,33 +530,31 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
                     return;
                 }
 
-                if (IsStaleDelayResult(cancellation, configVersion))
+                if (IsStaleSingleDelayResult(nodeName, cancellation, configVersion))
                 {
                     // 配置或令牌已变，过期延迟结果不能写回。
                     return;
                 }
 
-                _config = result.Config;
+                ApplyDelayResult(result);
                 _delayTestedNodeNames.UnionWith(result.TestedNodeNames);
-                RefreshSelectedGroup();
                 RaiseProxyStateChanged();
                 return;
             }
 
-            if (IsStaleDelayResult(cancellation, configVersion))
+            if (IsStaleSingleDelayResult(nodeName, cancellation, configVersion))
             {
                 return;
             }
 
             var fallbackResult = ProxyDelayFallback.TestNodes(_config, [nodeName]);
-            _config = fallbackResult.Config;
+            ApplyDelayResult(fallbackResult);
             _delayTestedNodeNames.UnionWith(fallbackResult.TestedNodeNames);
-            RefreshSelectedGroup();
             RaiseProxyStateChanged();
         }
         finally
         {
-            CompleteDelayTest(cancellation);
+            CompleteSingleDelayTest(nodeName, cancellation);
             cancellation.Dispose();
         }
     }
@@ -558,9 +562,11 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     public async Task TestAllDelaysAsync()
     {
         var nodeNames = AllGroupEntryNames();
+        var excludedNodeNames = ActiveSingleDelayTestNames();
         await RunBatchDelayTestAsync(
             nodeNames,
-            (config, progress, token) => _delayService!.TestAllAsync(config, progress, token));
+            excludedNodeNames,
+            (config, progress, token) => _delayService!.TestAllAsync(config, excludedNodeNames, progress, token));
     }
 
     public async Task TestCurrentGroupDelaysAsync()
@@ -586,21 +592,29 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
             return;
         }
 
+        var nodeNames = group.All;
+        var excludedNodeNames = ActiveSingleDelayTestNames();
         await RunBatchDelayTestAsync(
-            group.All,
-            (config, progress, token) => _delayService!.TestGroupAsync(config, group.Name, progress, token));
+            nodeNames,
+            excludedNodeNames,
+            (config, progress, token) => _delayService!.TestGroupAsync(config, group.Name, excludedNodeNames, progress, token));
     }
 
     private async Task RunBatchDelayTestAsync(
         IReadOnlyList<string> nodeNames,
+        IReadOnlyList<string> excludedNodeNames,
         Func<ProxyConfig, IProgress<ProxyDelayProgress>, CancellationToken, Task<ProxyDelayResult>> serviceCall)
     {
         if (nodeNames.Count == 0)
         {
+            _batchDelayTestedNodeNames.Clear();
+            _batchDelayTestedNodeNames.UnionWith(excludedNodeNames);
+            RaiseProxyStateChanged();
             return;
         }
 
-        var cancellation = BeginDelayTest(nodeNames, isBatch: true);
+        var batchNodeNames = nodeNames.Except(excludedNodeNames, StringComparer.Ordinal).ToList();
+        var cancellation = BeginBatchDelayTest(nodeNames, batchNodeNames);
         var configVersion = _configVersion;
         var progress = new Progress<ProxyDelayProgress>(item => OnDelayProgress(item, cancellation, configVersion));
         try
@@ -617,49 +631,51 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
                     return;
                 }
 
-                if (IsStaleDelayResult(cancellation, configVersion))
+                if (IsStaleBatchDelayResult(cancellation, configVersion))
                 {
                     return;
                 }
 
-                _config = result.Config;
+                ApplyDelayResult(result);
                 _delayTestedNodeNames.UnionWith(result.TestedNodeNames);
                 _batchDelayTestedNodeNames.Clear();
-                _batchDelayTestedNodeNames.UnionWith(result.TestedNodeNames.Concat(result.SkippedNodeNames));
-                RefreshSelectedGroup();
+                _batchDelayTestedNodeNames.UnionWith(
+                    result.TestedNodeNames.Concat(result.SkippedNodeNames));
                 RaiseProxyStateChanged();
                 return;
             }
 
-            if (IsStaleDelayResult(cancellation, configVersion))
+            if (IsStaleBatchDelayResult(cancellation, configVersion))
             {
                 return;
             }
 
-            var fallbackResult = ProxyDelayFallback.TestNodes(_config, nodeNames);
-            _config = fallbackResult.Config;
+            var fallbackResult = ProxyDelayFallback.TestNodes(_config, batchNodeNames);
+            ApplyDelayResult(fallbackResult);
             _delayTestedNodeNames.UnionWith(fallbackResult.TestedNodeNames);
             _batchDelayTestedNodeNames.Clear();
-            _batchDelayTestedNodeNames.UnionWith(fallbackResult.TestedNodeNames);
-            RefreshSelectedGroup();
+            _batchDelayTestedNodeNames.UnionWith(
+                fallbackResult.TestedNodeNames.Concat(nodeNames.Intersect(excludedNodeNames, StringComparer.Ordinal)));
             RaiseProxyStateChanged();
         }
         finally
         {
-            CompleteDelayTest(cancellation);
+            CompleteBatchDelayTest(cancellation);
             cancellation.Dispose();
         }
     }
 
     private void OnDelayProgress(ProxyDelayProgress progress, CancellationTokenSource cancellation, int configVersion)
     {
-        if (IsStaleDelayResult(cancellation, configVersion))
+        if (IsStaleBatchDelayResult(cancellation, configVersion))
         {
             return;
         }
 
         // 批量进度原地更新行；最终排序只刷新一次。
+        _batchDelayTestingNodeNames.Remove(progress.ProxyName);
         _delayTestingNodeNames.Remove(progress.ProxyName);
+        _batchDelayResults[progress.ProxyName] = progress.Delay;
         _delayTestedNodeNames.Add(progress.ProxyName);
         if (_nodeRowsByName.TryGetValue(progress.ProxyName, out var row))
         {
@@ -690,11 +706,15 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public void CancelDelayTests()
     {
-        _delayTestCancellation?.Cancel();
-        _delayTestCancellation = null;
-        _delayTestingNodeNames.Clear();
-        _isDelayTesting = false;
-        _isBatchDelayTesting = false;
+        _batchDelayTestCancellation?.Cancel();
+        _batchDelayTestCancellation = null;
+        _singleDelayTestCancellation?.Cancel();
+        _singleDelayTestCancellation = null;
+        _singleDelayTestingNodeName = null;
+        _batchDelayTargetNodeNames.Clear();
+        _batchDelayTestingNodeNames.Clear();
+        _batchDelayResults.Clear();
+        RefreshDelayTestingState();
         RaiseProxyStateChanged();
     }
 
@@ -781,11 +801,12 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     private void RefreshConfigIndexes()
     {
-        _visibleGroups = _config.VisibleGroups;
-        var entryNodes = new Dictionary<string, ProxyNode>(_config.Nodes, StringComparer.Ordinal);
-        foreach (var group in _config.Groups)
+        var visibleConfig = _config.WithEntryDelays(_batchDelayResults);
+        _visibleGroups = visibleConfig.VisibleGroups;
+        var entryNodes = new Dictionary<string, ProxyNode>(visibleConfig.Nodes, StringComparer.Ordinal);
+        foreach (var group in visibleConfig.Groups)
         {
-            _config.TryGetResolvedEntryDelay(group.Name, out var delay);
+            visibleConfig.TryGetResolvedEntryDelay(group.Name, out var delay);
             entryNodes.TryAdd(group.Name, new ProxyNode(group.Name, group.Type, delay));
         }
 
@@ -1000,39 +1021,115 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         };
     }
 
-    private CancellationTokenSource BeginDelayTest(IReadOnlyList<string> nodeNames, bool isBatch)
+    private CancellationTokenSource BeginSingleDelayTest(string nodeName)
     {
-        CancelDelayTests();
+        _singleDelayTestCancellation?.Cancel();
         var cancellation = new CancellationTokenSource();
-        _delayTestCancellation = cancellation;
-        _delayTestingNodeNames.Clear();
-        _delayTestingNodeNames.UnionWith(nodeNames);
-        _isDelayTesting = true;
-        _isBatchDelayTesting = isBatch;
+        _singleDelayTestCancellation = cancellation;
+        _singleDelayTestingNodeName = nodeName;
+        RefreshDelayTestingState();
         RaiseProxyStateChanged();
         return cancellation;
     }
 
-    private bool IsStaleDelayResult(CancellationTokenSource cancellation, int configVersion)
+    private CancellationTokenSource BeginBatchDelayTest(
+        IReadOnlyList<string> targetNodeNames,
+        IReadOnlyList<string> testingNodeNames)
     {
-        // 同时检查取消和配置版本，避免过期异步结果覆盖列表。
+        _batchDelayTestCancellation?.Cancel();
+        var cancellation = new CancellationTokenSource();
+        _batchDelayTestCancellation = cancellation;
+        _batchDelayTargetNodeNames.Clear();
+        _batchDelayTargetNodeNames.UnionWith(targetNodeNames);
+        _batchDelayTestingNodeNames.Clear();
+        _batchDelayResults.Clear();
+        _batchDelayTestingNodeNames.UnionWith(testingNodeNames);
+        RefreshDelayTestingState();
+        RaiseProxyStateChanged();
+        return cancellation;
+    }
+
+    private IReadOnlyList<string> ActiveSingleDelayTestNames()
+    {
+        return _singleDelayTestingNodeName is null
+            ? []
+            : [_singleDelayTestingNodeName];
+    }
+
+    private bool IsStaleSingleDelayResult(
+        string nodeName,
+        CancellationTokenSource cancellation,
+        int configVersion)
+    {
         return cancellation.IsCancellationRequested
-            || !ReferenceEquals(_delayTestCancellation, cancellation)
+            || !ReferenceEquals(_singleDelayTestCancellation, cancellation)
+            || !string.Equals(_singleDelayTestingNodeName, nodeName, StringComparison.Ordinal)
             || _configVersion != configVersion;
     }
 
-    private void CompleteDelayTest(CancellationTokenSource cancellation)
+    private bool IsStaleBatchDelayResult(CancellationTokenSource cancellation, int configVersion)
     {
-        if (!ReferenceEquals(_delayTestCancellation, cancellation))
+        return cancellation.IsCancellationRequested
+            || !ReferenceEquals(_batchDelayTestCancellation, cancellation)
+            || _configVersion != configVersion;
+    }
+
+    private void CompleteSingleDelayTest(string nodeName, CancellationTokenSource cancellation)
+    {
+        if (!ReferenceEquals(_singleDelayTestCancellation, cancellation)
+            || !string.Equals(_singleDelayTestingNodeName, nodeName, StringComparison.Ordinal))
         {
             return;
         }
 
-        _delayTestCancellation = null;
-        _delayTestingNodeNames.Clear();
-        _isDelayTesting = false;
-        _isBatchDelayTesting = false;
+        _singleDelayTestCancellation = null;
+        _singleDelayTestingNodeName = null;
+        RefreshDelayTestingState();
         RaiseProxyStateChanged();
+    }
+
+    private void CompleteBatchDelayTest(CancellationTokenSource cancellation)
+    {
+        if (!ReferenceEquals(_batchDelayTestCancellation, cancellation))
+        {
+            return;
+        }
+
+        _batchDelayTestCancellation = null;
+        _batchDelayTargetNodeNames.Clear();
+        _batchDelayTestingNodeNames.Clear();
+        _batchDelayResults.Clear();
+        RefreshDelayTestingState();
+        RaiseProxyStateChanged();
+    }
+
+    private void RefreshDelayTestingState()
+    {
+        _delayTestingNodeNames.Clear();
+        _delayTestingNodeNames.UnionWith(_batchDelayTestingNodeNames);
+        if (_singleDelayTestingNodeName is not null)
+        {
+            _delayTestingNodeNames.Add(_singleDelayTestingNodeName);
+        }
+
+        _isBatchDelayTesting = _batchDelayTestCancellation is not null;
+        _isDelayTesting = _isBatchDelayTesting || _singleDelayTestCancellation is not null;
+    }
+
+    private void ApplyDelayResult(ProxyDelayResult result)
+    {
+        var delays = result.TestedNodeNames
+            .Where(name => result.Config.TryGetEntryDelay(name, out _))
+            .ToDictionary(
+                name => name,
+                name =>
+                {
+                    result.Config.TryGetEntryDelay(name, out var delay);
+                    return delay ?? -1;
+                },
+                StringComparer.Ordinal);
+        _config = _config.WithEntryDelays(delays).WithEntryDelays(_batchDelayResults);
+        RefreshSelectedGroup();
     }
 
     public void Dispose()

--- a/src/Stelliberty.Presentation/ViewModels/Subscriptions/SubscriptionProviderViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Subscriptions/SubscriptionProviderViewModel.cs
@@ -566,6 +566,17 @@ public sealed class SubscriptionProviderViewModel : ViewModelBase, IDisposable
                 return;
             }
 
+            if (_catalog is not null)
+            {
+                await _catalog.ReloadProviderAsync(provider.Name);
+            }
+
+            await RefreshSelectedProviderCatalogAsync();
+            if (session != _selectorSession)
+            {
+                return;
+            }
+
             MarkProviderUploaded(provider.Name);
             _hasRefreshedAfterUpload = true;
             RaiseProviderStateChanged();

--- a/tests/Stelliberty.Infrastructure.Tests/FileSubscriptionProviderUploaderTests.cs
+++ b/tests/Stelliberty.Infrastructure.Tests/FileSubscriptionProviderUploaderTests.cs
@@ -1,0 +1,34 @@
+using Stelliberty.Domain.Subscriptions;
+using Stelliberty.Infrastructure.Subscriptions;
+using Xunit;
+
+namespace Stelliberty.Infrastructure.Tests;
+
+public sealed class FileSubscriptionProviderUploaderTests
+{
+    [Fact(DisplayName = "File provider upload saves relative path under configured core directory")]
+    public async Task FileProviderUploadSavesRelativePathUnderConfiguredCoreDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"stelliberty-provider-{Guid.NewGuid():N}");
+        var sourcePath = Path.Combine(root, "source.yaml");
+        var targetPath = Path.Combine(root, "providers", "demo.yaml");
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(sourcePath, "proxies: []\n");
+        try
+        {
+            var provider = new SubscriptionProvider("Demo", "proxy", "File", "./providers/demo.yaml", 0, null);
+            var uploader = new FileSubscriptionProviderUploader(root);
+
+            var result = await uploader.UploadAsync(provider, sourcePath);
+
+            Assert.True(result.IsUploaded);
+            await using var stream = new FileStream(targetPath, FileMode.Open, FileAccess.Read, FileShare.None, 4096, useAsync: true);
+            using var reader = new StreamReader(stream);
+            Assert.Equal("proxies: []\n", await reader.ReadToEndAsync());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Stelliberty.Infrastructure.Tests/PipeCoreProxyClientTests.cs
+++ b/tests/Stelliberty.Infrastructure.Tests/PipeCoreProxyClientTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Text;
+using Stelliberty.Application.Proxies;
+using Stelliberty.Domain.Proxies;
+using Stelliberty.Infrastructure.Proxies;
+using Xunit;
+
+namespace Stelliberty.Infrastructure.Tests;
+
+public sealed class PipeCoreProxyClientTests
+{
+    [Fact(DisplayName = "Core proxy client merges separated provider nodes from mihomo 1.19.28")]
+    public async Task CoreProxyClientMergesSeparatedProviderNodes()
+    {
+        using var client = CreateClient(
+            """
+            {
+              "proxies": {
+                "GLOBAL": { "type": "Selector", "now": "Select", "all": ["DIRECT", "Provider-US", "Select"] },
+                "Select": { "type": "Selector", "now": "Provider-US", "all": ["DIRECT", "Provider-US"] },
+                "DIRECT": { "type": "Direct" }
+              }
+            }
+            """,
+            """
+            {
+              "providers": {
+                "DemoProvider": {
+                  "name": "DemoProvider",
+                  "type": "Proxy",
+                  "vehicleType": "HTTP",
+                  "proxies": [
+                    { "name": "Provider-US", "type": "Vless" }
+                  ]
+                }
+              }
+            }
+            """);
+
+        var snapshot = await client.GetProxiesAsync();
+
+        Assert.Equal(["DIRECT", "Provider-US", "Select", "GLOBAL"], snapshot.Entries.Select(entry => entry.Name));
+        var providerNode = snapshot.Entries.Single(entry => entry.Name == "Provider-US");
+        Assert.Equal("Vless", providerNode.Type);
+        Assert.Equal("DemoProvider", providerNode.ProviderName);
+    }
+
+    [Fact(DisplayName = "Core delay tester uses provider healthcheck endpoint for provider nodes")]
+    public async Task CoreDelayTesterUsesProviderHealthcheckEndpoint()
+    {
+        var requestedPaths = new List<string>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri?.PathAndQuery ?? string.Empty);
+            return request.RequestUri?.AbsolutePath switch
+            {
+                "/providers/proxies/Demo%20Provider/Provider%2FUS/healthcheck" => JsonResponse("""{ "delay": 12 }"""),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            };
+        });
+        using var tester = new PipeCoreProxyDelayTester(
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") },
+            "http://delay.test/generate_204",
+            5000);
+
+        var delay = await tester.TestProviderDelayAsync("Demo Provider", "Provider/US");
+
+        Assert.Equal(12, delay);
+        Assert.Equal(
+            "/providers/proxies/Demo%20Provider/Provider%2FUS/healthcheck?timeout=5000&url=http%3A%2F%2Fdelay.test%2Fgenerate_204",
+            Assert.Single(requestedPaths));
+    }
+
+    [Fact(DisplayName = "Core delay tester keeps direct proxy endpoint for non-provider nodes")]
+    public async Task CoreDelayTesterKeepsDirectProxyEndpoint()
+    {
+        var requestedPaths = new List<string>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            requestedPaths.Add(request.RequestUri?.PathAndQuery ?? string.Empty);
+            return request.RequestUri?.AbsolutePath switch
+            {
+                "/proxies/DIRECT/delay" => JsonResponse("""{ "delay": 8 }"""),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            };
+        });
+        using var tester = new PipeCoreProxyDelayTester(
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") },
+            "http://delay.test/generate_204",
+            5000);
+
+        var delay = await tester.TestDelayAsync("DIRECT");
+
+        Assert.Equal(8, delay);
+        Assert.StartsWith("/proxies/DIRECT/delay?", Assert.Single(requestedPaths), StringComparison.Ordinal);
+    }
+
+    [Fact(DisplayName = "Proxy delay service routes provider node using runtime source metadata")]
+    public async Task ProxyDelayServiceRoutesProviderNodeUsingRuntimeSourceMetadata()
+    {
+        var tester = new RecordingProviderDelayTester();
+        var service = new ProxyDelayService(tester);
+        var config = new ProxyConfig(
+            [new ProxyGroup("Select", ProxyGroupTypes.Select, "Provider-US", ["Provider-US"])],
+            new Dictionary<string, ProxyNode>(StringComparer.Ordinal)
+            {
+                ["Provider-US"] = new ProxyNode("Provider-US", "Vless", ProviderName: "DemoProvider"),
+            });
+
+        var result = await service.TestNodeAsync(config, "Provider-US");
+
+        Assert.Equal(("DemoProvider", "Provider-US"), tester.ProviderRequest);
+        Assert.Empty(tester.DirectRequests);
+        Assert.Equal(12, result.Config.Nodes["Provider-US"].Delay);
+    }
+
+    [Fact(DisplayName = "Core proxy client propagates caller cancellation while loading providers")]
+    public async Task CoreProxyClientPropagatesCallerCancellation()
+    {
+        using var client = new PipeCoreProxyClient(new HttpClient(new BlockingHttpMessageHandler())
+        {
+            BaseAddress = new Uri("http://localhost/"),
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetProxiesAsync(cancellation.Token));
+    }
+
+    [Fact(DisplayName = "Core delay tester propagates caller cancellation during provider healthcheck")]
+    public async Task CoreDelayTesterPropagatesCallerCancellation()
+    {
+        using var tester = new PipeCoreProxyDelayTester(
+            new HttpClient(new BlockingHttpMessageHandler()) { BaseAddress = new Uri("http://localhost/") },
+            "http://delay.test/generate_204",
+            5000);
+        using var cancellation = new CancellationTokenSource();
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => tester.TestProviderDelayAsync("DemoProvider", "Provider-US", cancellation.Token));
+    }
+
+    private static PipeCoreProxyClient CreateClient(string proxiesJson, string providersJson)
+    {
+        var handler = new StubHttpMessageHandler(request => request.RequestUri?.AbsolutePath switch
+        {
+            "/proxies" => JsonResponse(proxiesJson),
+            "/providers/proxies" => JsonResponse(providersJson),
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+        });
+        return new PipeCoreProxyClient(new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") });
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class BlockingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Unreachable");
+        }
+    }
+
+    private sealed class RecordingProviderDelayTester : IProviderProxyDelayTester
+    {
+        public List<string> DirectRequests { get; } = [];
+
+        public (string ProviderName, string ProxyName)? ProviderRequest { get; private set; }
+
+        public Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken = default)
+        {
+            DirectRequests.Add(proxyName);
+            return Task.FromResult(8);
+        }
+
+        public Task<int> TestProviderDelayAsync(
+            string providerName,
+            string proxyName,
+            CancellationToken cancellationToken = default)
+        {
+            ProviderRequest = (providerName, proxyName);
+            return Task.FromResult(12);
+        }
+    }
+}

--- a/tests/Stelliberty.ProxyPage.Tests/ProxyPageViewModelTests.cs
+++ b/tests/Stelliberty.ProxyPage.Tests/ProxyPageViewModelTests.cs
@@ -410,6 +410,83 @@ public sealed class ProxyPageViewModelTests
         Assert.Equal(2, tester.CallCounts.Values.Sum());
     }
 
+    [Fact(DisplayName = "Batch delay skips a node with an active single delay test")]
+    public async Task BatchDelaySkipsNodeWithActiveSingleDelayTest()
+    {
+        var config = new ProxyConfig(
+            [new ProxyGroup("Select", ProxyGroupTypes.Select, "JP", ["JP", "KR", "US"])],
+            new Dictionary<string, ProxyNode>(StringComparer.Ordinal)
+            {
+                ["JP"] = new("JP", "ss"),
+                ["KR"] = new("KR", "vmess"),
+                ["US"] = new("US", "trojan")
+            },
+            OutboundMode.Rule);
+        var tester = new BlockingSingleProxyDelayTester("JP", "KR", 42, 99);
+        var page = new ProxyPageViewModel(delayService: new ProxyDelayService(tester));
+        page.LoadConfig(config);
+        page.SelectGroup("Select");
+
+        var singleTask = page.TestNodeDelayAsync("JP");
+        await tester.SingleStarted.Task.WaitAsync(AsyncTestTimeout);
+        Assert.True(page.IsDelayTesting);
+        Assert.False(page.IsBatchDelayTesting);
+
+        var batchTask = page.TestGroupDelaysAsync("Select");
+        await tester.BatchNodeTested.Task.WaitAsync(AsyncTestTimeout);
+
+        Assert.True(page.IsBatchDelayTesting);
+        Assert.Contains("JP", page.DelayTestingNodeNames);
+        Assert.DoesNotContain("JP", tester.BatchCalls);
+        Assert.Contains("KR", tester.BatchCalls);
+        Assert.Contains("US", tester.BatchCalls);
+        await tester.BatchNodeCompleted.Task.WaitAsync(AsyncTestTimeout);
+
+        tester.SingleRelease.TrySetResult();
+        await singleTask.WaitAsync(AsyncTestTimeout);
+        Assert.True(page.IsBatchDelayTesting);
+        Assert.True(page.IsDelayTesting);
+        Assert.DoesNotContain("JP", page.DelayTestingNodeNames);
+        Assert.Equal("42 ms", page.VisibleNodeRows.Single(row => row.Name == "JP").DelayText);
+        Assert.Equal("99 ms", page.VisibleNodeRows.Single(row => row.Name == "KR").DelayText);
+
+        page.SelectGroup("Select");
+        Assert.Equal("99 ms", page.VisibleNodeRows.Single(row => row.Name == "KR").DelayText);
+
+        tester.BatchRelease.TrySetResult();
+        await batchTask.WaitAsync(AsyncTestTimeout);
+        Assert.False(page.IsBatchDelayTesting);
+        Assert.False(page.IsDelayTesting);
+        Assert.Contains("JP", page.BatchDelayTestedNodeNames);
+        Assert.Equal("99 ms", page.VisibleNodeRows.Single(row => row.Name == "KR").DelayText);
+    }
+
+    [Fact(DisplayName = "Single delay does not duplicate a node already covered by a batch")]
+    public async Task SingleDelayDoesNotDuplicateNodeCoveredByBatch()
+    {
+        var tester = new BlockingBatchProxyDelayTester();
+        var page = new ProxyPageViewModel(delayService: new ProxyDelayService(tester));
+        page.LoadConfig(new ProxyConfig(
+            [new ProxyGroup("Select", ProxyGroupTypes.Select, "JP", ["JP"])],
+            new Dictionary<string, ProxyNode>(StringComparer.Ordinal)
+            {
+                ["JP"] = new("JP", "ss")
+            },
+            OutboundMode.Rule));
+
+        var batchTask = page.TestGroupDelaysAsync("Select");
+        await tester.Started.Task.WaitAsync(AsyncTestTimeout);
+
+        await page.TestNodeDelayAsync("JP");
+
+        Assert.Equal(1, tester.CallCount);
+        Assert.True(page.IsBatchDelayTesting);
+
+        tester.Release.TrySetResult();
+        await batchTask.WaitAsync(AsyncTestTimeout);
+        Assert.Equal("42 ms", page.VisibleNodeRows.Single().DelayText);
+    }
+
     [Fact(DisplayName = "External selection sync is skipped while delay testing")]
     public async Task ExternalSelectionSyncIsSkippedWhileDelayTesting()
     {
@@ -719,6 +796,65 @@ public sealed class ProxyPageViewModelTests
         {
             CallCounts[proxyName] = CallCounts.GetValueOrDefault(proxyName) + 1;
             return Task.FromResult(delays.TryGetValue(proxyName, out var delay) ? delay : -1);
+        }
+    }
+
+    private sealed class BlockingSingleProxyDelayTester(
+        string singleNodeName,
+        string completedBatchNodeName,
+        int singleDelay,
+        int batchDelay) : IProxyDelayTester
+    {
+        private int _singleStarted;
+
+        public TaskCompletionSource SingleStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource SingleRelease { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource BatchNodeTested { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource BatchNodeCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource BatchRelease { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<string> BatchCalls { get; } = [];
+
+        public async Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken = default)
+        {
+            if (proxyName == singleNodeName && Interlocked.Exchange(ref _singleStarted, 1) == 0)
+            {
+                SingleStarted.TrySetResult();
+                await SingleRelease.Task;
+                return singleDelay;
+            }
+
+            BatchCalls.Add(proxyName);
+            BatchNodeTested.TrySetResult();
+            if (proxyName == completedBatchNodeName)
+            {
+                BatchNodeCompleted.TrySetResult();
+                return batchDelay;
+            }
+
+            await BatchRelease.Task;
+            return batchDelay;
+        }
+    }
+
+    private sealed class BlockingBatchProxyDelayTester : IProxyDelayTester
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CallCount { get; private set; }
+
+        public async Task<int> TestDelayAsync(string proxyName, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            Started.TrySetResult();
+            await Release.Task;
+            return 42;
         }
     }
 

--- a/tests/Stelliberty.Subscription.Tests/SubscriptionBusinessTests.cs
+++ b/tests/Stelliberty.Subscription.Tests/SubscriptionBusinessTests.cs
@@ -1090,11 +1090,12 @@ public sealed class SubscriptionBusinessTests
         store.SaveContent("sub-1", ProviderConfig("remote-a", "file-a"));
         store.SaveContent("sub-2", ProviderConfig("remote-b", "file-b"));
         var selectionStore = new FakeSubscriptionSelectionStore("sub-1");
+        var syncer = new FakeSubscriptionProviderSyncer();
         var loader = new SelectedSubscriptionProviderCatalogLoader(
             store,
             selectionStore,
             new SubscriptionProviderParser(),
-            new FakeSubscriptionProviderSyncer());
+            syncer);
         var uploader = new FakeSubscriptionProviderUploader();
         var selector = new SubscriptionProviderViewModel(loader, uploader);
 
@@ -1105,6 +1106,7 @@ public sealed class SubscriptionBusinessTests
 
         Assert.Equal(["remote-a"], selector.SyncedProviderNames);
         Assert.Equal(["file-a"], selector.UploadedProviderNames);
+        Assert.Equal(["remote-a", "file-a"], syncer.SyncRequests);
         Assert.True(selector.Providers.Single(item => item.Name == "remote-a").IsSynced);
         Assert.True(selector.Providers.Single(item => item.Name == "file-a").IsUploaded);
 
@@ -1232,6 +1234,76 @@ public sealed class SubscriptionBusinessTests
         Assert.Empty(selector.UploadedProviderNames);
         Assert.False(selector.Providers.Single().IsUploaded);
         Assert.False(selector.HasRefreshedProvidersAfterUpload);
+        Assert.Equal(ToastType.Error, toast?.Type);
+        Assert.Equal("Subscriptions.Toast.ProviderUploadFailed", toast?.Message);
+    }
+
+    [Fact(DisplayName = "Provider selector reloads runtime node count after file upload")]
+    public async Task ProviderSelectorReloadsRuntimeNodeCountAfterFileUpload()
+    {
+        var store = new FakeSubscriptionStore([Subscription("sub-1")]);
+        store.SaveContent(
+            "sub-1",
+            """
+            proxy-providers:
+              file:
+                type: file
+                path: ./file.yaml
+            """);
+        var stateReader = new SequenceSubscriptionProviderStateReader(
+        [
+            [new SubscriptionProviderRuntimeState("file", "proxy", 0, null)],
+            [new SubscriptionProviderRuntimeState("file", "proxy", 1, DateTimeOffset.UnixEpoch.AddDays(1))],
+        ]);
+        var loader = new SelectedSubscriptionProviderCatalogLoader(
+            store,
+            new FakeSubscriptionSelectionStore("sub-1"),
+            new SubscriptionProviderParser(),
+            stateReader: stateReader);
+        var selector = new SubscriptionProviderViewModel(loader, new FakeSubscriptionProviderUploader());
+
+        await selector.ShowAsync("sub-1");
+        Assert.Equal(0, Assert.Single(selector.Providers).Count);
+
+        await selector.UploadProviderAsync("file", "test-data/providers/file.yaml");
+
+        Assert.Equal(1, Assert.Single(selector.Providers).Count);
+        Assert.True(selector.HasRefreshedProvidersAfterUpload);
+        Assert.Equal(["file"], selector.UploadedProviderNames);
+    }
+
+    [Fact(DisplayName = "Provider selector keeps upload incomplete when core runtime refresh fails")]
+    public async Task ProviderSelectorKeepsUploadIncompleteWhenCoreRuntimeRefreshFails()
+    {
+        var store = new FakeSubscriptionStore([Subscription("sub-1")]);
+        store.SaveContent(
+            "sub-1",
+            """
+            proxy-providers:
+              file:
+                type: file
+                path: ./file.yaml
+            """);
+        var syncer = new FakeSubscriptionProviderSyncer { FailingProviderNames = ["file"] };
+        var loader = new SelectedSubscriptionProviderCatalogLoader(
+            store,
+            new FakeSubscriptionSelectionStore("sub-1"),
+            new SubscriptionProviderParser(),
+            syncer);
+        var selector = new SubscriptionProviderViewModel(loader, new FakeSubscriptionProviderUploader());
+        (string Message, ToastType Type)? toast = null;
+        SubscriptionProviderSyncCompletedEventArgs? synced = null;
+        selector.ToastRequested += (_, args) => toast = args;
+        selector.ProvidersSynced += (_, args) => synced = args;
+        await selector.ShowAsync("sub-1");
+
+        await selector.UploadProviderAsync("file", "test-data/providers/file.yaml");
+
+        Assert.Equal(["file"], syncer.SyncRequests);
+        Assert.Empty(selector.UploadedProviderNames);
+        Assert.False(Assert.Single(selector.Providers).IsUploaded);
+        Assert.False(selector.HasRefreshedProvidersAfterUpload);
+        Assert.Null(synced);
         Assert.Equal(ToastType.Error, toast?.Type);
         Assert.Equal("Subscriptions.Toast.ProviderUploadFailed", toast?.Message);
     }
@@ -1601,6 +1673,19 @@ public sealed class SubscriptionBusinessTests
             }
 
             return Task.FromResult(new RemoteSubscriptionDownloadResult(Content));
+        }
+    }
+
+    private sealed class SequenceSubscriptionProviderStateReader(
+        IReadOnlyList<IReadOnlyList<SubscriptionProviderRuntimeState>> states) : ISubscriptionProviderStateReader
+    {
+        private int _index;
+
+        public Task<IReadOnlyList<SubscriptionProviderRuntimeState>> ReadStatesAsync(CancellationToken cancellationToken = default)
+        {
+            var current = states[Math.Min(_index, states.Count - 1)];
+            _index++;
+            return Task.FromResult(current);
         }
     }
 


### PR DESCRIPTION
## Summary

- Restore Proxy Provider nodes and delay testing with mihomo v1.19.28
- Preserve completed results across concurrent node and batch delay tests
- Constrain long proxy node tooltips and improve beta build change detection
- Update the application version to 2.0.2

## Validation

- `PYTHONUTF8=1 python scripts/test.py --csharp` (13 groups, 260 tests)
- Verified a real File Provider upload from 0 to 1 runtime node in the Debug app
- Verified Provider delay testing through the mihomo healthcheck endpoint

Closes #76