### PR TITLE
release: promote v2.0.3 to stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,9 +1,11 @@
 - Proxy Provider nodes remain visible, selectable, and available for delay testing with the latest mihomo core.
 - Individual and batch delay tests can run together without losing completed results.
 - Long proxy node tooltips now wrap within a limited height.
+- Service mode stays available after installing an app update.
 
 ---
 
 - 使用最新版 mihomo 核心时，Proxy Provider 节点仍可正常显示、选择并进行延迟测试。
 - 单节点与批量延迟测试现在可以同时运行，已完成的结果不会丢失。
 - 较长的代理节点提示文字现在会在限定高度内换行显示。
+- 安装应用更新后，服务模式仍可正常使用。

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,11 +1,5 @@
-- Proxy Provider nodes remain visible, selectable, and available for delay testing with the latest mihomo core.
-- Individual and batch delay tests can run together without losing completed results.
-- Long proxy node tooltips now wrap within a limited height.
-- Service mode stays available after installing an app update.
+- Service mode remains available after installing an app update.
 
 ---
 
-- 使用最新版 mihomo 核心时，Proxy Provider 节点仍可正常显示、选择并进行延迟测试。
-- 单节点与批量延迟测试现在可以同时运行，已完成的结果不会丢失。
-- 较长的代理节点提示文字现在会在限定高度内换行显示。
 - 安装应用更新后，服务模式仍可正常使用。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     directory: /
     target-branch: beta
     schedule:
-      interval: weekly
-      day: monday
-      time: "07:00"
+      interval: cron
+      cronjob: "0 7 * * 0,1,3,5"
       timezone: America/New_York
     groups:
       nuget-dependencies:
@@ -18,9 +17,8 @@ updates:
     directory: /
     target-branch: beta
     schedule:
-      interval: weekly
-      day: monday
-      time: "07:00"
+      interval: cron
+      cronjob: "0 7 * * 0,1,3,5"
       timezone: America/New_York
     groups:
       cargo-dependencies:

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -37,6 +37,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
       release_notes: ${{ steps.notes.outputs.release_notes }}
+      can_build: ${{ steps.base-tag.outputs.can_build }}
 
     steps:
       - name: Check out repository
@@ -112,8 +113,25 @@ jobs:
             printf -- '- Tag: `%s`\n' "${TAG}"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Verify beta base tag
+        id: base-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          previous_tag="${{ steps.ver.outputs.previous_tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${previous_tag}" >/dev/null 2>&1; then
+            echo 'can_build=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'can_build=false' >> "$GITHUB_OUTPUT"
+          echo "::notice::Beta build skipped because base tag ${previous_tag} does not exist."
+          echo "Beta build skipped because base tag \`${previous_tag}\` does not exist." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Generate beta release notes
         id: notes
+        if: steps.base-tag.outputs.can_build == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -138,6 +156,7 @@ jobs:
   build:
     name: Build / ${{ matrix.label }}
     needs: prepare
+    if: needs.prepare.outputs.can_build == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
 
@@ -317,8 +336,8 @@ jobs:
   release:
     name: Publish beta to download repository
     needs: [prepare, build]
+    if: ${{ needs.prepare.outputs.can_build == 'true' && needs.build.result == 'success' }}
     runs-on: ubuntu-22.04
-    if: ${{ needs.build.result == 'success' }}
 
     steps:
       - name: Download beta artifacts

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -91,21 +91,25 @@ jobs:
       - name: Export beta metadata
         id: meta
         shell: bash
+        env:
+          APP_NAME: ${{ steps.names.outputs.app_name }}
+          APP_DISPLAY_NAME: ${{ steps.names.outputs.app_display_name }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          TAG: ${{ steps.ver.outputs.tag }}
         run: |
           set -euo pipefail
           {
-            echo "app_name=${{ steps.names.outputs.app_name }}"
-            echo "app_display_name=${{ steps.names.outputs.app_display_name }}"
-            echo "version=${{ steps.ver.outputs.version }}"
-            echo "tag=${{ steps.ver.outputs.tag }}"
+            printf 'app_name=%s\n' "${APP_NAME}"
+            printf 'app_display_name=%s\n' "${APP_DISPLAY_NAME}"
+            printf 'version=%s\n' "${VERSION}"
+            printf 'tag=%s\n' "${TAG}"
           } >> "$GITHUB_OUTPUT"
           {
-            echo "### Release Metadata"
-            echo ""
-            echo "- App: `${{ steps.names.outputs.app_display_name }}`"
-            echo "- Channel: `beta`"
-            echo "- Version: `${{ steps.ver.outputs.version }}`"
-            echo "- Tag: `${{ steps.ver.outputs.tag }}`"
+            printf '### Release Metadata\n\n'
+            printf -- '- App: `%s`\n' "${APP_DISPLAY_NAME}"
+            printf -- '- Channel: `beta`\n'
+            printf -- '- Version: `%s`\n' "${VERSION}"
+            printf -- '- Tag: `%s`\n' "${TAG}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate beta release notes

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -105,3 +105,25 @@ jobs:
       }}
     uses: ./.github/workflows/build-beta.yml
     secrets: inherit
+
+  beta-build-not-required:
+    name: Beta build not required
+    needs: [detect-beta-build-changes, code-quality, stability-verification]
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/beta' &&
+        needs.detect-beta-build-changes.result == 'success' &&
+        needs.detect-beta-build-changes.outputs.should_build != 'true' &&
+        needs.code-quality.result == 'success' &&
+        needs.stability-verification.result == 'success'
+      }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report intentional skip
+        shell: bash
+        run: |
+          echo '::notice::Verification passed; no product changes require a beta build.'
+          echo '### Beta Build' >> "$GITHUB_STEP_SUMMARY"
+          echo 'Verification passed. The beta build was intentionally skipped because no product files changed.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -64,7 +64,7 @@ jobs:
 
           while IFS= read -r path; do
             case "${path}" in
-              *.cs|*.rs|*.axaml|*.csproj|Directory.Build.props|Cargo.toml)
+              *.cs|*.rs|*.axaml|Directory.Build.props)
                 should_build=true
                 break
                 ;;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.2</AppVersion>
+    <AppVersion>2.0.3</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/hub/Cargo.toml
+++ b/native/hub/Cargo.toml
@@ -22,7 +22,7 @@ interprocess = { version = "^2.4.2", features = ["tokio"] }
 async-trait = "^0.1.89"
 tokio-tungstenite = "^0.30"
 futures-util = "^0.3"
-age = { version = "^0.11.3", features = ["armor"] }
+age = { version = "^0.12.0", features = ["armor"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "^0.62.2", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging", "Win32_Security"] }

--- a/scripts/installer/windows/setup.iss.in
+++ b/scripts/installer/windows/setup.iss.in
@@ -85,7 +85,7 @@ zhHant.UninstallCancel=選擇「取消」將停止解除安裝。
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "@SOURCE_DIR@\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "@SOURCE_DIR@\*"; DestDir: "{app}"; Flags: replacesameversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
@@ -98,8 +98,6 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 var
   ResetDirButton: TButton;
   CleanUserData: Boolean;
-  HadService: Boolean;
-  WasServiceRunning: Boolean;
 
 function GetSystemDrive(): String;
 var
@@ -272,34 +270,13 @@ begin
   end;
 end;
 
-function InitializeSetup(): Boolean;
-begin
-  Result := True;
-  HadService := ServiceExists();
-  WasServiceRunning := ServiceRunning();
-end;
-
 procedure CurStepChanged(CurStep: TSetupStep);
-var
-  ServiceExe: String;
 begin
   if CurStep = ssInstall then
   begin
-    if HadService then
-      StopServiceIfNeeded();
     StopAppProcessIfNeeded();
     StopCoreProcessIfNeeded();
   end
-  else if CurStep = ssPostInstall then
-  begin
-    ServiceExe := ExpandConstant('{app}\data\service\update\{#MyServiceBinary}');
-    if HadService and FileExists(ServiceExe) then
-    begin
-      RunHidden(ServiceExe, 'install');
-      if not WasServiceRunning then
-        RunHidden('sc.exe', 'stop {#MyServiceName}');
-    end;
-  end;
 end;
 
 function InitializeUninstall(): Boolean;

--- a/src/Stelliberty.Application/Diagnostics/AppLogSanitizer.cs
+++ b/src/Stelliberty.Application/Diagnostics/AppLogSanitizer.cs
@@ -6,31 +6,34 @@ public static class AppLogSanitizer
 {
     private const string Mask = "<redacted>";
     private const int MaxMessageLength = 6000;
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+    private const RegexOptions SafeRegexOptions = RegexOptions.IgnoreCase
+        | RegexOptions.CultureInvariant
+        | RegexOptions.NonBacktracking;
 
     private static readonly Regex HttpUrlRegex = new(
         @"\bhttps?://[^\s""'<>]+",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        SafeRegexOptions,
         RegexTimeout);
 
     private static readonly Regex ProxyUriRegex = new(
         @"\b(?:ss|ssr|vmess|vless|trojan|hysteria2|hy2|tuic|socks|socks5|snell)://[^\s""'<>]+",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        SafeRegexOptions,
         RegexTimeout);
 
     private static readonly Regex AuthorizationHeaderRegex = new(
         @"(?<prefix>\b(?:authorization|proxy-authorization)\s*[:=]\s*)(?<value>[^,;]+)",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        SafeRegexOptions,
         RegexTimeout);
 
     private static readonly Regex BearerTokenRegex = new(
         @"(?<prefix>\b(?:bearer|basic)\s+)[A-Za-z0-9._~+/=-]+",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        SafeRegexOptions,
         RegexTimeout);
 
     private static readonly Regex SensitiveKeyValueRegex = new(
         @"(?<prefix>\b(?:access[-_]?token|refresh[-_]?token|id[-_]?token|token|secret|password|passwd|pwd|api[-_]?key|apikey|authorization|auth|user[-_]?agent|ua|url|source)\b\s*[:=]\s*)(?<quote>[""']?)(?<value>[^""'\s,;]+)(?<close>[""']?)",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        SafeRegexOptions,
         RegexTimeout);
 
     public static string Sanitize(string? message)
@@ -40,20 +43,28 @@ public static class AppLogSanitizer
             return string.Empty;
         }
 
-        var sanitized = Flatten(message);
-        sanitized = SanitizePathPrefixes(sanitized);
-        sanitized = HttpUrlRegex.Replace(sanitized, match => SanitizeHttpUrl(match.Value));
-        sanitized = ProxyUriRegex.Replace(sanitized, match => SanitizeProxyUri(match.Value));
-        sanitized = AuthorizationHeaderRegex.Replace(sanitized, match => $"{match.Groups["prefix"].Value}{Mask}");
-        sanitized = BearerTokenRegex.Replace(sanitized, match => $"{match.Groups["prefix"].Value}{Mask}");
-        sanitized = SensitiveKeyValueRegex.Replace(sanitized, match =>
+        try
         {
-            var quote = match.Groups["quote"].Value;
-            return $"{match.Groups["prefix"].Value}{quote}{Mask}{quote}";
-        });
-        sanitized = CollapseAdjacentMasks(sanitized);
+            var sanitized = Flatten(message.Length <= MaxMessageLength ? message : message[..MaxMessageLength]);
+            sanitized = SanitizePathPrefixes(sanitized);
+            sanitized = HttpUrlRegex.Replace(sanitized, match => SanitizeHttpUrl(match.Value));
+            sanitized = ProxyUriRegex.Replace(sanitized, match => SanitizeProxyUri(match.Value));
+            sanitized = AuthorizationHeaderRegex.Replace(sanitized, match => $"{match.Groups["prefix"].Value}{Mask}");
+            sanitized = BearerTokenRegex.Replace(sanitized, match => $"{match.Groups["prefix"].Value}{Mask}");
+            sanitized = SensitiveKeyValueRegex.Replace(sanitized, match =>
+            {
+                var quote = match.Groups["quote"].Value;
+                return $"{match.Groups["prefix"].Value}{quote}{Mask}{quote}";
+            });
+            sanitized = CollapseAdjacentMasks(sanitized);
 
-        return sanitized.Length <= MaxMessageLength ? sanitized : sanitized[..MaxMessageLength] + "...";
+            return message.Length <= MaxMessageLength ? sanitized : sanitized + "...";
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // 脱敏失败时封闭返回，避免日志导致启动失败或泄漏原文。
+            return Mask;
+        }
     }
 
     private static string Flatten(string message)


### PR DESCRIPTION
## Summary

Promote the v2.0.3 beta line to stable.

### Fixes
- Preserve the service host during app updates so service mode keeps working after an update.
- Prevent macOS x64 simulation startup timeout in CI.

### CI
- Fix metadata output and dependency schedule for the beta workflow.
- Skip builds without a published base tag.

### Dependencies
- Update `age` to 0.12.0.

### Docs
- Rewrite the v2.0.3 changelog and bump the app version to 2.0.3.

## Tested
- CI build workflows.