### PR TITLE
chore(release): promote v2.0.4 to stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,35 @@
-- Service mode remains available after installing an app update.
+- Windows startup settings now wait for permission-sensitive changes to succeed, avoid unrelated task prompts, and start after a one-second delay.
+- Proxy sorting now persists across app and core restarts, while horizontal group navigation supports smooth wheel and button scrolling.
+- Replacing the macOS or Linux application now preserves portable user data outside the replaceable application payload.
+- macOS now reports the correct application name and follows simplified Chinese system localization more reliably.
+- Subscription imports no longer fail when the stored subscription list is missing or incomplete.
+
+## Upgrading from versions before 2.0.0 [v2.0.0]
+
+Version 2.0.0 was a major rewrite and does not retain compatibility with installation state from the old Flutter version. Before installing this release over an older version:
+
+1. Disable and uninstall startup integration in the old version.
+2. Uninstall service mode in the old version.
+3. Exit and uninstall the old application completely.
+4. Install the current version only after the previous steps are complete.
+
+Skipping these steps may leave old startup or service components on the system and cause unexpected behavior.
 
 ---
 
-- 安装应用更新后，服务模式仍可正常使用。
+- Windows 开机启动设置现在会等待权限相关操作成功后再更新状态，不再触发无关的任务弹窗，并在 1 秒延时后启动。
+- 代理排序现在能够在应用和内核重启后保持，横向分组导航同时支持平滑的滚轮与按钮滚动。
+- 替换 macOS 或 Linux 应用时，便携用户数据现在会保存在可替换应用文件之外，不再随应用一起被覆盖。
+- macOS 现在能够显示正确的应用名称，并能更可靠地跟随简体中文系统语言。
+- 订阅列表缺失或内容不完整时，导入订阅不再失败。
+
+## 从 2.0.0 之前的版本升级 [v2.0.0]
+
+2.0.0 是一次大规模重构，不兼容旧 Flutter 版本留下的安装状态。从旧版本升级到当前版本前，请依次完成以下操作：
+
+1. 在旧版本中关闭并卸载开机启动。
+2. 在旧版本中卸载服务模式。
+3. 完全退出并卸载旧应用。
+4. 确认以上步骤完成后，再安装当前版本。
+
+跳过这些步骤可能导致系统中残留旧版开机启动项或服务组件，进而引发异常行为。

--- a/.github/scripts/installation_persistence_simulation.py
+++ b/.github/scripts/installation_persistence_simulation.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate installer replacement while preserving portable data")
+    parser.add_argument("--os-family", required=True, choices=["linux", "macos"])
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="stelliberty-installation-") as temporary_directory:
+        root = Path(temporary_directory)
+        if args.os_family == "macos":
+            verify_macos_layout_policy()
+            simulate_macos_replacement(root)
+        else:
+            verify_linux_installer_policy()
+            simulate_linux_package_replacement(root)
+            simulate_appimage_replacement(root)
+
+
+def verify_macos_layout_policy() -> None:
+    resolver = read_repository_file("src/Stelliberty.Application/Platform/PortableDataDirectoryResolver.cs")
+    require_fragments(resolver, ["ResolveMacOS", '".app"', '}.data'])
+
+
+def verify_linux_installer_policy() -> None:
+    launcher = read_repository_file("scripts/installer/linux/launcher.in")
+    appimage = read_repository_file("scripts/installer/linux/appimage.AppRun.in")
+    require_fragments(launcher, ["STELLIBERTY_APP_DATA_DIR", "/opt/@APP_PACKAGE@.data"])
+    require_fragments(appimage, ["STELLIBERTY_APP_DATA_DIR", "APPIMAGE_DIR", "@APP_PACKAGE@.data"])
+
+    for relative_path in [
+        "scripts/installer/linux/postinst.in",
+        "scripts/installer/linux/arch.INSTALL.in",
+        "scripts/installer/linux/rpm.spec.in",
+    ]:
+        require_fragments(read_repository_file(relative_path), ["mkdir -p /opt/@APP_PACKAGE@.data"])
+
+
+def simulate_macos_replacement(root: Path) -> None:
+    applications_directory = root / "Applications"
+    app_directory = applications_directory / "Stelliberty.app"
+    data_directory = applications_directory / "Stelliberty.data"
+
+    install_version(app_directory / "Contents" / "MacOS", "1")
+    save_user_state(data_directory)
+    replace_installation(app_directory, app_directory / "Contents" / "MacOS", "2")
+    require_preserved(data_directory, app_directory / "Contents" / "MacOS")
+
+
+def simulate_linux_package_replacement(root: Path) -> None:
+    install_directory = root / "opt" / "stelliberty"
+    data_directory = root / "opt" / "stelliberty.data"
+
+    install_version(install_directory, "1")
+    save_user_state(data_directory)
+    replace_installation(install_directory, install_directory, "2")
+    require_preserved(data_directory, install_directory)
+
+
+def simulate_appimage_replacement(root: Path) -> None:
+    extraction_root = root / "home" / "runner" / ".local" / "share" / "stelliberty" / "appimage"
+    first_installation = extraction_root / "1"
+    second_installation = extraction_root / "2"
+    data_directory = root / "downloads" / "stelliberty.data"
+
+    install_version(first_installation, "1")
+    save_user_state(data_directory)
+    shutil.rmtree(first_installation)
+    install_version(second_installation, "2")
+    require_preserved(data_directory, second_installation)
+
+
+def replace_installation(installation_root: Path, payload_directory: Path, version: str) -> None:
+    shutil.rmtree(installation_root)
+    install_version(payload_directory, version)
+
+
+def install_version(install_directory: Path, version: str) -> None:
+    install_directory.mkdir(parents=True, exist_ok=True)
+    (install_directory / "version").write_text(version, encoding="utf-8")
+
+
+def save_user_state(data_directory: Path) -> None:
+    data_directory.mkdir(parents=True, exist_ok=True)
+    (data_directory / "settings.json").write_text("saved", encoding="utf-8")
+
+
+def require_preserved(data_directory: Path, install_directory: Path) -> None:
+    settings = (data_directory / "settings.json").read_text(encoding="utf-8")
+    version = (install_directory / "version").read_text(encoding="utf-8")
+    if settings != "saved" or version != "2":
+        raise RuntimeError("Installer replacement did not preserve portable data")
+
+
+def read_repository_file(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def require_fragments(content: str, fragments: list[str]) -> None:
+    missing = [fragment for fragment in fragments if fragment not in content]
+    if missing:
+        raise RuntimeError(f"Installation persistence policy is incomplete: {missing}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/installation_persistence_simulation.py
+++ b/.github/scripts/installation_persistence_simulation.py
@@ -31,8 +31,8 @@ def verify_macos_layout_policy() -> None:
 def verify_linux_installer_policy() -> None:
     launcher = read_repository_file("scripts/installer/linux/launcher.in")
     appimage = read_repository_file("scripts/installer/linux/appimage.AppRun.in")
-    require_fragments(launcher, ["STELLIBERTY_APP_DATA_DIR", "/opt/@APP_PACKAGE@.data"])
-    require_fragments(appimage, ["STELLIBERTY_APP_DATA_DIR", "APPIMAGE_DIR", "@APP_PACKAGE@.data"])
+    require_fragments(launcher, ["PORTABLE_APP_DATA_DIR", "/opt/@APP_PACKAGE@.data"])
+    require_fragments(appimage, ["PORTABLE_APP_DATA_DIR", "APPIMAGE_DIR", "@APP_PACKAGE@.data"])
 
     for relative_path in [
         "scripts/installer/linux/postinst.in",
@@ -43,6 +43,7 @@ def verify_linux_installer_policy() -> None:
 
 
 def simulate_macos_replacement(root: Path) -> None:
+    print("Simulating macOS app bundle replacement")
     applications_directory = root / "Applications"
     app_directory = applications_directory / "Stelliberty.app"
     data_directory = applications_directory / "Stelliberty.data"
@@ -54,6 +55,7 @@ def simulate_macos_replacement(root: Path) -> None:
 
 
 def simulate_linux_package_replacement(root: Path) -> None:
+    print("Simulating Linux package replacement")
     install_directory = root / "opt" / "stelliberty"
     data_directory = root / "opt" / "stelliberty.data"
 
@@ -64,6 +66,7 @@ def simulate_linux_package_replacement(root: Path) -> None:
 
 
 def simulate_appimage_replacement(root: Path) -> None:
+    print("Simulating AppImage version replacement")
     extraction_root = root / "home" / "runner" / ".local" / "share" / "stelliberty" / "appimage"
     first_installation = extraction_root / "1"
     second_installation = extraction_root / "2"

--- a/.github/scripts/installation_persistence_simulation.py
+++ b/.github/scripts/installation_persistence_simulation.py
@@ -10,17 +10,20 @@ ROOT = Path(__file__).resolve().parents[2]
 def main() -> None:
     parser = argparse.ArgumentParser(description="Simulate installer replacement while preserving portable data")
     parser.add_argument("--os-family", required=True, choices=["linux", "macos"])
+    parser.add_argument("--app-output", required=True, type=Path)
     args = parser.parse_args()
+    if not args.app_output.is_dir():
+        raise FileNotFoundError(f"Built app output does not exist: {args.app_output}")
 
     with tempfile.TemporaryDirectory(prefix="stelliberty-installation-") as temporary_directory:
         root = Path(temporary_directory)
         if args.os_family == "macos":
             verify_macos_layout_policy()
-            simulate_macos_replacement(root)
+            simulate_macos_replacement(root, args.app_output)
         else:
             verify_linux_installer_policy()
-            simulate_linux_package_replacement(root)
-            simulate_appimage_replacement(root)
+            simulate_linux_package_replacement(root, args.app_output)
+            simulate_appimage_replacement(root, args.app_output)
 
 
 def verify_macos_layout_policy() -> None:
@@ -42,51 +45,51 @@ def verify_linux_installer_policy() -> None:
         require_fragments(read_repository_file(relative_path), ["mkdir -p /opt/@APP_PACKAGE@.data"])
 
 
-def simulate_macos_replacement(root: Path) -> None:
+def simulate_macos_replacement(root: Path, app_output: Path) -> None:
     print("Simulating macOS app bundle replacement")
     applications_directory = root / "Applications"
     app_directory = applications_directory / "Stelliberty.app"
     data_directory = applications_directory / "Stelliberty.data"
 
-    install_version(app_directory / "Contents" / "MacOS", "1")
+    install_version(app_output, app_directory / "Contents" / "MacOS", "1")
     save_user_state(data_directory)
-    replace_installation(app_directory, app_directory / "Contents" / "MacOS", "2")
+    replace_installation(app_output, app_directory, app_directory / "Contents" / "MacOS", "2")
     require_preserved(data_directory, app_directory / "Contents" / "MacOS")
 
 
-def simulate_linux_package_replacement(root: Path) -> None:
+def simulate_linux_package_replacement(root: Path, app_output: Path) -> None:
     print("Simulating Linux package replacement")
     install_directory = root / "opt" / "stelliberty"
     data_directory = root / "opt" / "stelliberty.data"
 
-    install_version(install_directory, "1")
+    install_version(app_output, install_directory, "1")
     save_user_state(data_directory)
-    replace_installation(install_directory, install_directory, "2")
+    replace_installation(app_output, install_directory, install_directory, "2")
     require_preserved(data_directory, install_directory)
 
 
-def simulate_appimage_replacement(root: Path) -> None:
+def simulate_appimage_replacement(root: Path, app_output: Path) -> None:
     print("Simulating AppImage version replacement")
     extraction_root = root / "home" / "runner" / ".local" / "share" / "stelliberty" / "appimage"
     first_installation = extraction_root / "1"
     second_installation = extraction_root / "2"
     data_directory = root / "downloads" / "stelliberty.data"
 
-    install_version(first_installation, "1")
+    install_version(app_output, first_installation, "1")
     save_user_state(data_directory)
     shutil.rmtree(first_installation)
-    install_version(second_installation, "2")
+    install_version(app_output, second_installation, "2")
     require_preserved(data_directory, second_installation)
 
 
-def replace_installation(installation_root: Path, payload_directory: Path, version: str) -> None:
+def replace_installation(app_output: Path, installation_root: Path, payload_directory: Path, version: str) -> None:
     shutil.rmtree(installation_root)
-    install_version(payload_directory, version)
+    install_version(app_output, payload_directory, version)
 
 
-def install_version(install_directory: Path, version: str) -> None:
-    install_directory.mkdir(parents=True, exist_ok=True)
-    (install_directory / "version").write_text(version, encoding="utf-8")
+def install_version(app_output: Path, install_directory: Path, version: str) -> None:
+    shutil.copytree(app_output, install_directory)
+    (install_directory / ".simulation-version").write_text(version, encoding="utf-8")
 
 
 def save_user_state(data_directory: Path) -> None:
@@ -96,7 +99,7 @@ def save_user_state(data_directory: Path) -> None:
 
 def require_preserved(data_directory: Path, install_directory: Path) -> None:
     settings = (data_directory / "settings.json").read_text(encoding="utf-8")
-    version = (install_directory / "version").read_text(encoding="utf-8")
+    version = (install_directory / ".simulation-version").read_text(encoding="utf-8")
     if settings != "saved" or version != "2":
         raise RuntimeError("Installer replacement did not preserve portable data")
 

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -9,6 +9,8 @@ on:
       - 'native/**'
       - 'tests/**'
       - 'scripts/**'
+      - '.github/scripts/**'
+      - '.github/workflows/stability-verification.yml'
       - 'Directory.Build.props'
       - 'Stelliberty.slnx'
       - 'Cargo.toml'

--- a/.github/workflows/stability-verification.yml
+++ b/.github/workflows/stability-verification.yml
@@ -15,6 +15,37 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
+  installation-persistence:
+    name: Installation Persistence / ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Linux
+            runner: ubuntu-22.04
+            os_family: linux
+          - label: macOS
+            runner: macos-26
+            os_family: macos
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Simulate installation replacement
+        shell: bash
+        run: |
+          set -euo pipefail
+          python .github/scripts/installation_persistence_simulation.py --os-family ${{ matrix.os_family }}
+
   tests:
     name: Pre-build Tests + Post-build Simulation Tests / ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/stability-verification.yml
+++ b/.github/workflows/stability-verification.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   installation-persistence:
-    name: Installation Persistence / ${{ matrix.label }}
+    name: Installer Data Persistence / ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
 
@@ -45,6 +45,8 @@ jobs:
         run: |
           set -euo pipefail
           python .github/scripts/installation_persistence_simulation.py --os-family ${{ matrix.os_family }}
+          echo "### Installer Data Persistence" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ matrix.label }} replacement simulation preserved portable data." >> "$GITHUB_STEP_SUMMARY"
 
   tests:
     name: Pre-build Tests + Post-build Simulation Tests / ${{ matrix.label }}

--- a/.github/workflows/stability-verification.yml
+++ b/.github/workflows/stability-verification.yml
@@ -150,15 +150,6 @@ jobs:
           set -euo pipefail
           python scripts/build.py --dev --platform ${{ matrix.platform }}
 
-      - name: Simulate installer data persistence
-        if: matrix.os_family == 'linux' || matrix.os_family == 'macos'
-        shell: bash
-        run: |
-          set -euo pipefail
-          python .github/scripts/installation_persistence_simulation.py --os-family ${{ matrix.os_family }}
-          echo "### Installer Data Persistence" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ matrix.label }} replacement simulation preserved portable data." >> "$GITHUB_STEP_SUMMARY"
-
       - name: Resolve app entry point
         shell: bash
         run: |
@@ -173,6 +164,17 @@ jobs:
             executable="${executable}.exe"
           fi
           printf 'APP_EXEC=%s\nAPP_OUTPUT=%s\n' "${executable}" "${output}" >> "$GITHUB_ENV"
+
+      - name: Simulate installer data persistence
+        if: matrix.os_family == 'linux' || matrix.os_family == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python .github/scripts/installation_persistence_simulation.py \
+            --os-family ${{ matrix.os_family }} \
+            --app-output "$APP_OUTPUT"
+          echo "### Installer Data Persistence" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ matrix.label }} replacement simulation preserved the built payload and portable data." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Windows post-build simulation tests
         if: matrix.os_family == 'windows'

--- a/.github/workflows/stability-verification.yml
+++ b/.github/workflows/stability-verification.yml
@@ -15,39 +15,6 @@ env:
   RUST_BACKTRACE: "1"
 
 jobs:
-  installation-persistence:
-    name: Installer Data Persistence / ${{ matrix.label }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - label: Linux
-            runner: ubuntu-22.04
-            os_family: linux
-          - label: macOS
-            runner: macos-26
-            os_family: macos
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-
-      - name: Simulate installation replacement
-        shell: bash
-        run: |
-          set -euo pipefail
-          python .github/scripts/installation_persistence_simulation.py --os-family ${{ matrix.os_family }}
-          echo "### Installer Data Persistence" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ matrix.label }} replacement simulation preserved portable data." >> "$GITHUB_STEP_SUMMARY"
-
   tests:
     name: Pre-build Tests + Post-build Simulation Tests / ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
@@ -182,6 +149,15 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/build.py --dev --platform ${{ matrix.platform }}
+
+      - name: Simulate installer data persistence
+        if: matrix.os_family == 'linux' || matrix.os_family == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python .github/scripts/installation_persistence_simulation.py --os-family ${{ matrix.os_family }}
+          echo "### Installer Data Persistence" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ matrix.label }} replacement simulation preserved portable data." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Resolve app entry point
         shell: bash

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.3</AppVersion>
+    <AppVersion>2.0.4</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/scripts/installer/linux/appimage.AppRun.in
+++ b/scripts/installer/linux/appimage.AppRun.in
@@ -7,7 +7,7 @@ TARGET="$DATA_HOME/@APP_PACKAGE@/appimage/@APP_VERSION@"
 MARKER="$TARGET/.appimage-source"
 APPIMAGE_PATH="${APPIMAGE:-$0}"
 APPIMAGE_DIR="$(dirname "$(readlink -f "$APPIMAGE_PATH")")"
-export STELLIBERTY_APP_DATA_DIR="$APPIMAGE_DIR/@APP_PACKAGE@.data"
+export PORTABLE_APP_DATA_DIR="$APPIMAGE_DIR/@APP_PACKAGE@.data"
 
 if [ ! -x "$TARGET/@APP_EXECUTABLE@" ] || [ "$(cat "$MARKER" 2>/dev/null || true)" != "$HERE" ]; then
     rm -rf "$TARGET"

--- a/scripts/installer/linux/appimage.AppRun.in
+++ b/scripts/installer/linux/appimage.AppRun.in
@@ -5,6 +5,9 @@ HERE="$(dirname "$(readlink -f "$0")")"
 DATA_HOME="${XDG_DATA_HOME:-${HOME:-/tmp}/.local/share}"
 TARGET="$DATA_HOME/@APP_PACKAGE@/appimage/@APP_VERSION@"
 MARKER="$TARGET/.appimage-source"
+APPIMAGE_PATH="${APPIMAGE:-$0}"
+APPIMAGE_DIR="$(dirname "$(readlink -f "$APPIMAGE_PATH")")"
+export STELLIBERTY_APP_DATA_DIR="$APPIMAGE_DIR/@APP_PACKAGE@.data"
 
 if [ ! -x "$TARGET/@APP_EXECUTABLE@" ] || [ "$(cat "$MARKER" 2>/dev/null || true)" != "$HERE" ]; then
     rm -rf "$TARGET"

--- a/scripts/installer/linux/arch.INSTALL.in
+++ b/scripts/installer/linux/arch.INSTALL.in
@@ -3,6 +3,8 @@ post_install() {
     chmod 755 /opt/@APP_PACKAGE@/data/core/clash-mihomo-core 2>/dev/null || true
     chmod 755 /opt/@APP_PACKAGE@/data/service/update/@SERVICE_BINARY@ 2>/dev/null || true
     chmod -R a+rwX /opt/@APP_PACKAGE@/data 2>/dev/null || true
+    mkdir -p /opt/@APP_PACKAGE@.data
+    chmod -R a+rwX /opt/@APP_PACKAGE@.data 2>/dev/null || true
 
     if command -v update-desktop-database >/dev/null 2>&1; then
         update-desktop-database /usr/share/applications || true

--- a/scripts/installer/linux/launcher.in
+++ b/scripts/installer/linux/launcher.in
@@ -1,2 +1,3 @@
 #!/bin/sh
+export STELLIBERTY_APP_DATA_DIR="/opt/@APP_PACKAGE@.data"
 exec /opt/@APP_PACKAGE@/@APP_EXECUTABLE@ "$@"

--- a/scripts/installer/linux/launcher.in
+++ b/scripts/installer/linux/launcher.in
@@ -1,3 +1,3 @@
 #!/bin/sh
-export STELLIBERTY_APP_DATA_DIR="/opt/@APP_PACKAGE@.data"
+export PORTABLE_APP_DATA_DIR="/opt/@APP_PACKAGE@.data"
 exec /opt/@APP_PACKAGE@/@APP_EXECUTABLE@ "$@"

--- a/scripts/installer/linux/postinst.in
+++ b/scripts/installer/linux/postinst.in
@@ -5,6 +5,8 @@ chmod 755 /opt/@APP_PACKAGE@/@APP_EXECUTABLE@ || true
 chmod 755 /opt/@APP_PACKAGE@/data/core/clash-mihomo-core || true
 chmod 755 /opt/@APP_PACKAGE@/data/service/update/@SERVICE_BINARY@ || true
 chmod -R a+rwX /opt/@APP_PACKAGE@/data || true
+mkdir -p /opt/@APP_PACKAGE@.data
+chmod -R a+rwX /opt/@APP_PACKAGE@.data || true
 
 if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database /usr/share/applications || true

--- a/scripts/installer/linux/rpm.spec.in
+++ b/scripts/installer/linux/rpm.spec.in
@@ -31,6 +31,8 @@ chmod 755 /opt/@APP_PACKAGE@/@APP_EXECUTABLE@ || true
 chmod 755 /opt/@APP_PACKAGE@/data/core/clash-mihomo-core || true
 chmod 755 /opt/@APP_PACKAGE@/data/service/update/@SERVICE_BINARY@ || true
 chmod -R a+rwX /opt/@APP_PACKAGE@/data || true
+mkdir -p /opt/@APP_PACKAGE@.data
+chmod -R a+rwX /opt/@APP_PACKAGE@.data || true
 if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database /usr/share/applications || true
 fi

--- a/scripts/installer/macos/Info.plist.in
+++ b/scripts/installer/macos/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleDevelopmentRegion</key>
-    <string>zh_CN</string>
+    <string>zh-Hans</string>
     <key>CFBundleExecutable</key>
     <string>@APP_EXECUTABLE@</string>
     <key>CFBundleIconFile</key>
@@ -14,6 +14,14 @@
     <string>6.0</string>
     <key>CFBundleName</key>
     <string>@APP_NAME@</string>
+    <key>CFBundleDisplayName</key>
+    <string>@APP_NAME@</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>zh-Hans</string>
+        <string>zh-Hant</string>
+        <string>en</string>
+    </array>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/src/Stelliberty.Application/Platform/PathConventions.cs
+++ b/src/Stelliberty.Application/Platform/PathConventions.cs
@@ -13,5 +13,5 @@ public static class PathConventions
     public const string AppLogsSubdirectory = "applogs";
     public const string SettingsFileName = "settings.json";
     public const string RunningLogFileName = "running.logs";
-    public const string AppDataDirectoryEnvironmentVariable = "STELLIBERTY_APP_DATA_DIR";
+    public const string PortableDataDirectoryEnvironmentVariable = "PORTABLE_APP_DATA_DIR";
 }

--- a/src/Stelliberty.Application/Platform/PathConventions.cs
+++ b/src/Stelliberty.Application/Platform/PathConventions.cs
@@ -13,4 +13,5 @@ public static class PathConventions
     public const string AppLogsSubdirectory = "applogs";
     public const string SettingsFileName = "settings.json";
     public const string RunningLogFileName = "running.logs";
+    public const string AppDataDirectoryEnvironmentVariable = "STELLIBERTY_APP_DATA_DIR";
 }

--- a/src/Stelliberty.Application/Platform/PortableDataDirectoryResolver.cs
+++ b/src/Stelliberty.Application/Platform/PortableDataDirectoryResolver.cs
@@ -1,0 +1,33 @@
+namespace Stelliberty.Application.Platform;
+
+public static class PortableDataDirectoryResolver
+{
+    public static string ResolveMacOS(string baseDirectory)
+    {
+        var installDataDirectory = InstallDataDirectory(baseDirectory);
+        var macOSDirectory = new DirectoryInfo(Path.TrimEndingDirectorySeparator(baseDirectory));
+        var contentsDirectory = macOSDirectory.Parent;
+        var bundleDirectory = contentsDirectory?.Parent;
+        if (macOSDirectory.Name != "MacOS"
+            || contentsDirectory?.Name != "Contents"
+            || bundleDirectory is not { Parent: { } bundleParent }
+            || !string.Equals(bundleDirectory.Extension, ".app", StringComparison.OrdinalIgnoreCase))
+        {
+            return installDataDirectory;
+        }
+
+        return Path.Combine(
+            bundleParent.FullName,
+            $"{Path.GetFileNameWithoutExtension(bundleDirectory.Name)}.data");
+    }
+
+    public static string ResolveLinux(string baseDirectory, string? configuredDataDirectory)
+    {
+        return string.IsNullOrWhiteSpace(configuredDataDirectory)
+            ? InstallDataDirectory(baseDirectory)
+            : Path.GetFullPath(configuredDataDirectory);
+    }
+
+    private static string InstallDataDirectory(string baseDirectory) =>
+        Path.Combine(baseDirectory, PathConventions.DataDirectoryName);
+}

--- a/src/Stelliberty.Application/Settings/AppSettings.cs
+++ b/src/Stelliberty.Application/Settings/AppSettings.cs
@@ -73,6 +73,8 @@ public sealed class AppSettings
 
     public string ProxyPageLayout { get; set; } = "Horizontal";
 
+    public string ProxyNodeSortMode { get; set; } = "Default";
+
     public string DelayTestUrl { get; set; } = "https://www.gstatic.com/generate_204";
 
     public bool IsAllowLanEnabled { get; set; }

--- a/src/Stelliberty.Desktop/App.axaml
+++ b/src/Stelliberty.Desktop/App.axaml
@@ -2,7 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:chrome="clr-namespace:Avalonia.Controls.Chrome;assembly=Avalonia.Controls"
              xmlns:semi="https://irihi.tech/semi"
-             x:Class="Stelliberty.Desktop.App">
+             x:Class="Stelliberty.Desktop.App"
+             Name="Stelliberty">
   <Application.Resources>
     <ResourceDictionary>
       <ControlTheme x:Key="{x:Type chrome:WindowDrawnDecorations}"

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -211,6 +211,9 @@ public sealed partial class App : Avalonia.Application
             var proxyPageLayout = Enum.TryParse<ProxyPageLayout>(settings.ProxyPageLayout, ignoreCase: true, out var parsedProxyLayout)
                 ? parsedProxyLayout
                 : ProxyPageLayout.Horizontal;
+            var proxyNodeSortMode = Enum.TryParse<ProxyNodeSortMode>(settings.ProxyNodeSortMode, ignoreCase: true, out var parsedProxyNodeSortMode)
+                ? parsedProxyNodeSortMode
+                : ProxyNodeSortMode.Default;
             var proxyPage = new ProxyPageViewModel(
                 proxyConfigLoader,
                 new ProxyDelayService(proxyDelayTester),
@@ -224,6 +227,12 @@ public sealed partial class App : Avalonia.Application
                 {
                     // 复用共享设置实例，避免后续完整保存丢失这个偏好。
                     settings.ProxyPageLayout = layout.ToString();
+                    settingsStore.Save(settings);
+                },
+                initialSortMode: proxyNodeSortMode,
+                persistSortMode: sortMode =>
+                {
+                    settings.ProxyNodeSortMode = sortMode.ToString();
                     settingsStore.Save(settings);
                 });
             var rulePage = new RulePageViewModel(new RuleListLoader(

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -42,7 +42,6 @@ namespace Stelliberty.Desktop;
 
 public sealed partial class App : Avalonia.Application
 {
-    private const string SilentStartArgument = "--silent-start";
     private readonly DesktopTrayService _trayService = new();
     private SessionEndCleanupService? _sessionEndCleanup;
     private DispatcherTimer? _appUpdateAutoCheckTimer;
@@ -288,7 +287,7 @@ public sealed partial class App : Avalonia.Application
                 DataContext = viewModel
             };
 
-            var shouldStartHidden = ShouldStartHidden(desktop, settings);
+            var shouldStartHidden = ShouldStartHidden(settings);
             if (shouldStartHidden)
             {
                 // 静默启动没有首个可见窗口，退出必须来自托盘或调试命令。
@@ -333,14 +332,9 @@ public sealed partial class App : Avalonia.Application
         base.OnFrameworkInitializationCompleted();
     }
 
-    private static bool ShouldStartHidden(IClassicDesktopStyleApplicationLifetime desktop, AppSettings settings)
+    private static bool ShouldStartHidden(AppSettings settings)
     {
-        return settings.IsSilentStartEnabled || HasSilentStartArgument(desktop.Args);
-    }
-
-    private static bool HasSilentStartArgument(string[]? args)
-    {
-        return args?.Any(arg => string.Equals(arg, SilentStartArgument, StringComparison.OrdinalIgnoreCase)) == true;
+        return settings.IsSilentStartEnabled;
     }
 
     private void StopBackgroundServices()

--- a/src/Stelliberty.Desktop/Debug/Commands/Proxies.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Proxies.cs
@@ -156,6 +156,7 @@ internal static partial class DebugCommands
             $"batch={page.IsBatchDelayTesting.ToString().ToLowerInvariant()}",
             $"tested={string.Join(',', testedNodeNames)}",
             $"layout={page.LayoutMode.ToString().ToLowerInvariant()}",
+            $"sort={page.SortMode.ToString().ToLowerInvariant()}",
             $"expanded={page.ExpandedGroupName ?? string.Empty}"
         ]);
     }

--- a/src/Stelliberty.Desktop/Debug/Commands/Settings.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Settings.cs
@@ -684,7 +684,7 @@ internal static partial class DebugCommands
             case "minimize-to-tray": behavior.IsMinimizeToTrayEnabled = ParseBool(normalizedValue); break;
             case "tray-double-click": behavior.IsTrayDoubleClickEnabled = ParseBool(normalizedValue); break;
             case "lazy-mode": behavior.IsLazyModeEnabled = ParseBool(normalizedValue); break;
-            case "auto-start": behavior.IsAutoStartEnabled = ParseBool(normalizedValue); break;
+            case "auto-start": behavior.SetAutoStartEnabled(ParseBool(normalizedValue)); break;
             default: throw new InvalidOperationException($"Unknown app behavior setting: {key}");
         }
     }

--- a/src/Stelliberty.Desktop/Services/DesktopApplicationLayout.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopApplicationLayout.cs
@@ -6,17 +6,26 @@ internal static class DesktopApplicationLayout
 {
     private static string BaseDirectory => AppContext.BaseDirectory;
 
-    public static string AppDataDirectory => Path.Combine(BaseDirectory, PathConventions.DataDirectoryName);
+    private static string InstallDataDirectory => Path.Combine(BaseDirectory, PathConventions.DataDirectoryName);
 
-    public static string DepsDirectory => Path.Combine(AppDataDirectory, PathConventions.DepsSubdirectory);
+    // 安装资源随版本替换，用户数据固定在安装载体之外。
+    public static string AppDataDirectory => OperatingSystem.IsMacOS()
+        ? PortableDataDirectoryResolver.ResolveMacOS(BaseDirectory)
+        : OperatingSystem.IsLinux()
+            ? PortableDataDirectoryResolver.ResolveLinux(
+                BaseDirectory,
+                Environment.GetEnvironmentVariable(PathConventions.AppDataDirectoryEnvironmentVariable))
+            : InstallDataDirectory;
 
-    public static string CoreDirectory => Path.Combine(AppDataDirectory, PathConventions.CoreSubdirectory);
+    public static string DepsDirectory => Path.Combine(InstallDataDirectory, PathConventions.DepsSubdirectory);
+
+    public static string CoreDirectory => Path.Combine(InstallDataDirectory, PathConventions.CoreSubdirectory);
 
     public static string CoreBinaryPath => Path.Combine(CoreDirectory, CoreBinaryName);
 
     public static string ServiceDirectory => Path.Combine(AppDataDirectory, PathConventions.ServiceSubdirectory);
 
-    public static string ServiceUpdateDirectory => Path.Combine(ServiceDirectory, PathConventions.ServiceUpdateSubdirectory);
+    public static string ServiceUpdateDirectory => Path.Combine(InstallDataDirectory, PathConventions.ServiceSubdirectory, PathConventions.ServiceUpdateSubdirectory);
 
     public static string ServiceCommandBinaryPath => Path.Combine(ServiceUpdateDirectory, ServiceBinaryName);
 
@@ -37,4 +46,5 @@ internal static class DesktopApplicationLayout
     private static string ServiceInstalledBinaryName => OperatingSystem.IsWindows()
         ? $"{PathConventions.ServiceInstalledBinaryStem}.exe"
         : PathConventions.ServiceInstalledBinaryStem;
+
 }

--- a/src/Stelliberty.Desktop/Services/DesktopApplicationLayout.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopApplicationLayout.cs
@@ -14,7 +14,7 @@ internal static class DesktopApplicationLayout
         : OperatingSystem.IsLinux()
             ? PortableDataDirectoryResolver.ResolveLinux(
                 BaseDirectory,
-                Environment.GetEnvironmentVariable(PathConventions.AppDataDirectoryEnvironmentVariable))
+                Environment.GetEnvironmentVariable(PathConventions.PortableDataDirectoryEnvironmentVariable))
             : InstallDataDirectory;
 
     public static string DepsDirectory => Path.Combine(InstallDataDirectory, PathConventions.DepsSubdirectory);

--- a/src/Stelliberty.Desktop/Styles/SettingsStyles.axaml
+++ b/src/Stelliberty.Desktop/Styles/SettingsStyles.axaml
@@ -114,6 +114,24 @@
     <Setter Property="Background" Value="Transparent" />
   </Style>
 
+  <Style Selector="Button.settings-toggle-command">
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="MinWidth" Value="0" />
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <Style Selector="Button.settings-toggle-command:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+  </Style>
+  <Style Selector="Button.settings-toggle-command:pressed /template/ ContentPresenter#PART_ContentPresenter">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Opacity" Value="1" />
+  </Style>
+
   <Style Selector="TextBlock.settings-row-title">
     <Setter Property="FontSize" Value="14" />
     <Setter Property="FontWeight" Value="SemiBold" />

--- a/src/Stelliberty.Desktop/Views/ProxyView.axaml
+++ b/src/Stelliberty.Desktop/Views/ProxyView.axaml
@@ -25,6 +25,11 @@
                         AutomationProperties.AutomationId="Proxy.GroupBarScroll"
                         HorizontalScrollBarVisibility="Hidden"
                         VerticalScrollBarVisibility="Disabled">
+            <ScrollViewer.Transitions>
+              <Transitions>
+                <VectorTransition Property="Offset" Duration="0:0:0.16" Easing="CubicEaseOut" />
+              </Transitions>
+            </ScrollViewer.Transitions>
             <Grid>
               <ItemsControl AutomationProperties.AutomationId="Proxy.GroupBar"
                             ItemsSource="{Binding VisibleGroupRows}">

--- a/src/Stelliberty.Desktop/Views/ProxyView.axaml.cs
+++ b/src/Stelliberty.Desktop/Views/ProxyView.axaml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -11,6 +12,8 @@ namespace Stelliberty.Desktop.Views;
 
 public sealed partial class ProxyView : UserControl
 {
+    // 单格滚轮约移动一个分组标签，触控板增量仍按比例生效。
+    private const double GroupTabsWheelStep = 72;
     private ProxyPageViewModel? _attachedViewModel;
     private int _handledScrollToTopRequestId;
     private double _savedNodeScrollOffset;
@@ -18,6 +21,11 @@ public sealed partial class ProxyView : UserControl
     public ProxyView()
     {
         InitializeComponent();
+        GroupTabsScroll.AddHandler(
+            InputElement.PointerWheelChangedEvent,
+            OnGroupTabsPointerWheelChanged,
+            RoutingStrategies.Tunnel,
+            handledEventsToo: true);
         ProxyPageRoot.DataContextChanged += OnDataContextChanged;
         AttachViewModel();
     }
@@ -135,5 +143,19 @@ public sealed partial class ProxyView : UserControl
         var step = GroupTabsScroll.Viewport.Width * 0.6;
         var maxX = Math.Max(0, GroupTabsScroll.Extent.Width - GroupTabsScroll.Viewport.Width);
         GroupTabsScroll.Offset = GroupTabsScroll.Offset.WithX(Math.Min(maxX, GroupTabsScroll.Offset.X + step));
+    }
+
+    private void OnGroupTabsPointerWheelChanged(object? sender, PointerWheelEventArgs args)
+    {
+        var delta = Math.Abs(args.Delta.X) > Math.Abs(args.Delta.Y) ? args.Delta.X : args.Delta.Y;
+        var maxX = Math.Max(0, GroupTabsScroll.Extent.Width - GroupTabsScroll.Viewport.Width);
+        var nextX = Math.Clamp(GroupTabsScroll.Offset.X - delta * GroupTabsWheelStep, 0, maxX);
+        if (Math.Abs(nextX - GroupTabsScroll.Offset.X) < 0.5)
+        {
+            return;
+        }
+
+        GroupTabsScroll.Offset = GroupTabsScroll.Offset.WithX(nextX);
+        args.Handled = true;
     }
 }

--- a/src/Stelliberty.Desktop/Views/Settings/SettingsAppBehaviorView.axaml
+++ b/src/Stelliberty.Desktop/Views/Settings/SettingsAppBehaviorView.axaml
@@ -71,7 +71,8 @@
           <TextBlock Grid.Column="0" Classes="settings-row-title" Text="{Binding AppBehavior.StartupText}" />
           <ToggleSwitch Grid.Column="1"
                         AutomationProperties.AutomationId="Settings.AutoStartToggle"
-                        IsChecked="{Binding AppBehavior.IsAutoStartEnabled, Mode=TwoWay}" />
+                        Command="{Binding AppBehavior.ToggleAutoStartCommand}"
+                        IsChecked="{Binding AppBehavior.IsAutoStartEnabled, Mode=OneWay}" />
         </Grid>
       </Border>
     </StackPanel>

--- a/src/Stelliberty.Desktop/Views/Settings/SettingsAppBehaviorView.axaml
+++ b/src/Stelliberty.Desktop/Views/Settings/SettingsAppBehaviorView.axaml
@@ -69,10 +69,14 @@
       <Border Classes="settings-inline-row">
         <Grid ColumnDefinitions="*,Auto">
           <TextBlock Grid.Column="0" Classes="settings-row-title" Text="{Binding AppBehavior.StartupText}" />
-          <ToggleSwitch Grid.Column="1"
-                        AutomationProperties.AutomationId="Settings.AutoStartToggle"
-                        Command="{Binding AppBehavior.ToggleAutoStartCommand}"
-                        IsChecked="{Binding AppBehavior.IsAutoStartEnabled, Mode=OneWay}" />
+          <Button Grid.Column="1"
+                  Classes="settings-toggle-command"
+                  AutomationProperties.AutomationId="Settings.AutoStartToggle"
+                  Command="{Binding AppBehavior.ToggleAutoStartCommand}">
+            <ToggleSwitch Focusable="False"
+                          IsHitTestVisible="False"
+                          IsChecked="{Binding AppBehavior.IsAutoStartEnabled, Mode=OneWay}" />
+          </Button>
         </Grid>
       </Border>
     </StackPanel>

--- a/src/Stelliberty.Infrastructure/DataManagement/FileDataBackupService.cs
+++ b/src/Stelliberty.Infrastructure/DataManagement/FileDataBackupService.cs
@@ -30,6 +30,7 @@ public sealed class FileDataBackupService(string appDataDirectory) : IDataManage
         "IsUnifiedDelayEnabled",
         "OutboundMode",
         "ProxyPageLayout",
+        "ProxyNodeSortMode",
         "DelayTestUrl",
         "IsAllowLanEnabled",
         "LanAuthenticationUserName",

--- a/src/Stelliberty.Infrastructure/Platform/AutoStartEntryBuilder.cs
+++ b/src/Stelliberty.Infrastructure/Platform/AutoStartEntryBuilder.cs
@@ -33,7 +33,7 @@ public static class AutoStartEntryBuilder
             "  <Triggers>",
             "    <LogonTrigger>",
             "      <Enabled>true</Enabled>",
-            "      <Delay>PT2S</Delay>"
+            "      <Delay>PT1S</Delay>"
         };
 
         if (!string.IsNullOrWhiteSpace(userId))
@@ -55,7 +55,7 @@ public static class AutoStartEntryBuilder
         }
 
         lines.Add("      <LogonType>InteractiveToken</LogonType>");
-        lines.Add("      <RunLevel>HighestAvailable</RunLevel>");
+        lines.Add("      <RunLevel>LeastPrivilege</RunLevel>");
         lines.AddRange(
         [
             "    </Principal>",
@@ -79,11 +79,6 @@ public static class AutoStartEntryBuilder
             "    <Exec>",
             $"      <Command>{Xml(binaryPath)}</Command>"
         ]);
-
-        if (isSilentStartEnabled)
-        {
-            lines.Add("      <Arguments>--silent-start</Arguments>");
-        }
 
         if (!string.IsNullOrWhiteSpace(workingDirectory))
         {

--- a/src/Stelliberty.Infrastructure/Platform/AutoStartEntryBuilder.cs
+++ b/src/Stelliberty.Infrastructure/Platform/AutoStartEntryBuilder.cs
@@ -20,7 +20,7 @@ public static class AutoStartEntryBuilder
     public const string LinuxDesktopFileName = EntryName + ".desktop";
     public const string MacOSLaunchAgentFileName = LaunchAgentLabel + ".plist";
 
-    public static string WindowsScheduledTaskXml(string binaryPath, bool isSilentStartEnabled, string? userId = null)
+    public static string WindowsScheduledTaskXml(string binaryPath, string? userId = null)
     {
         var workingDirectory = Path.GetDirectoryName(binaryPath);
         var lines = new List<string>

--- a/src/Stelliberty.Infrastructure/Platform/WindowsAppBehaviorService.cs
+++ b/src/Stelliberty.Infrastructure/Platform/WindowsAppBehaviorService.cs
@@ -15,11 +15,11 @@ public sealed class WindowsAppBehaviorService : IAppBehaviorService
 
     public void Apply(AppBehaviorApplicationRequest request)
     {
-        ApplyAutoStart(request.IsAutoStartEnabled, request.IsSilentStartEnabled);
+        ApplyAutoStart(request.IsAutoStartEnabled);
         AppLogger.Info($"Windows app behavior applied: autoStart={request.IsAutoStartEnabled}");
     }
 
-    private static void ApplyAutoStart(bool isEnabled, bool isSilentStartEnabled)
+    private static void ApplyAutoStart(bool isEnabled)
     {
         if (!isEnabled)
         {
@@ -38,13 +38,13 @@ public sealed class WindowsAppBehaviorService : IAppBehaviorService
             return;
         }
 
-        if (!RegisterScheduledTask(binaryPath, isSilentStartEnabled))
+        if (!RegisterScheduledTask(binaryPath))
         {
             throw new InvalidOperationException("Windows autostart scheduled task registration failed.");
         }
     }
 
-    private static bool RegisterScheduledTask(string binaryPath, bool isSilentStartEnabled)
+    private static bool RegisterScheduledTask(string binaryPath)
     {
         var xmlPath = Path.Combine(
             Path.GetTempPath(),
@@ -53,7 +53,7 @@ public sealed class WindowsAppBehaviorService : IAppBehaviorService
         {
             File.WriteAllText(
                 xmlPath,
-                AutoStartEntryBuilder.WindowsScheduledTaskXml(binaryPath, isSilentStartEnabled, CurrentUserSid()),
+                AutoStartEntryBuilder.WindowsScheduledTaskXml(binaryPath, CurrentUserSid()),
                 Encoding.Unicode);
             var result = RunSchtasks(
                 ["/create", "/tn", AutoStartEntryBuilder.WindowsTaskName, "/xml", xmlPath, "/f"],

--- a/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionStore.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Subscriptions;
 using Stelliberty.Domain.Subscriptions;
@@ -61,7 +62,7 @@ public sealed class FileSubscriptionStore(string rootDirectory) : ISubscriptionS
     public IReadOnlyList<Subscription> LoadSubscriptions()
     {
         var list = JsonFileRecovery.ReadOrRecover<StoredSubscriptionListFile>(_listPath) ?? new StoredSubscriptionListFile([]);
-        return list.Subscriptions.Select(subscription => subscription.ToSubscription()).ToList();
+        return (list.Subscriptions ?? []).Select(subscription => subscription.ToSubscription()).ToList();
     }
 
     public string ReadContent(string subscriptionId)
@@ -99,8 +100,10 @@ public sealed class FileSubscriptionStore(string rootDirectory) : ISubscriptionS
 
     private sealed record SubscriptionListFile(IReadOnlyList<Subscription> Subscriptions);
 
-    private sealed record StoredSubscriptionListFile(IReadOnlyList<StoredSubscription> Subscriptions);
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+    private sealed record StoredSubscriptionListFile(IReadOnlyList<StoredSubscription>? Subscriptions);
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     private sealed record StoredSubscription(
         string Id,
         string Name,

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -19,6 +19,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private readonly IProxyConfigProvider? _primaryConfigProvider;
     private readonly IProxyConfigProvider? _fallbackConfigProvider;
     private readonly ILocalizationService? _localization;
+    private readonly Action<ProxyNodeSortMode>? _persistSortMode;
+    private readonly Action<ProxyPageLayout>? _persistLayout;
     private ProxyConfig _config = new([], new Dictionary<string, ProxyNode>());
     private IReadOnlyList<ProxyGroup> _visibleGroups = [];
     private IReadOnlyDictionary<string, ProxyNode> _entryNodes = new Dictionary<string, ProxyNode>(StringComparer.Ordinal);
@@ -34,7 +36,6 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private string _searchKeyword = string.Empty;
     private ProxyPageLayout _layoutMode;
     private string? _expandedGroupName;
-    private readonly Action<ProxyPageLayout>? _persistLayout;
     private Domain.Proxies.OutboundMode _outboundMode = Domain.Proxies.OutboundMode.Rule;
     private bool _isCoreRunning;
     private readonly HashSet<string> _delayTestedNodeNames = new(StringComparer.Ordinal);
@@ -73,7 +74,9 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         ILocalizationService? localization = null,
         ProxySelectionService? selectionService = null,
         ProxyPageLayout initialLayout = ProxyPageLayout.Horizontal,
-        Action<ProxyPageLayout>? persistLayout = null)
+        Action<ProxyPageLayout>? persistLayout = null,
+        ProxyNodeSortMode initialSortMode = ProxyNodeSortMode.Default,
+        Action<ProxyNodeSortMode>? persistSortMode = null)
     {
         _loader = loader;
         _delayService = delayService;
@@ -82,6 +85,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         _primaryConfigProvider = primaryConfigProvider;
         _fallbackConfigProvider = fallbackConfigProvider;
         _localization = localization;
+        _sortMode = initialSortMode;
+        _persistSortMode = persistSortMode;
         _layoutMode = initialLayout;
         _persistLayout = persistLayout;
         _emptyText = Localize("Proxy.Empty.NoGroups");
@@ -369,6 +374,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         }
 
         _sortMode = mode;
+        _persistSortMode?.Invoke(mode);
         RaiseProxyStateChanged();
     }
 

--- a/src/Stelliberty.Presentation/ViewModels/Settings/SettingsAppBehaviorViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Settings/SettingsAppBehaviorViewModel.cs
@@ -1,8 +1,10 @@
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Localization;
 using Stelliberty.Application.Platform;
 using Stelliberty.Application.Settings;
+using Stelliberty.Presentation.Commands;
 
 namespace Stelliberty.Presentation.ViewModels;
 
@@ -24,6 +26,7 @@ public sealed class SettingsAppBehaviorViewModel : ViewModelBase, IDisposable
         _settingsStore = settingsStore;
         _localization = localization;
         _service = service;
+        ToggleAutoStartCommand = new RelayCommand(() => SetAutoStartEnabled(!IsAutoStartEnabled));
         _localization.LanguageChanged += OnLanguageChanged;
     }
 
@@ -90,16 +93,36 @@ public sealed class SettingsAppBehaviorViewModel : ViewModelBase, IDisposable
         set => Apply(_settings.IsTrayDoubleClickEnabled, value, next => _settings.IsTrayDoubleClickEnabled = next);
     }
 
-    public bool IsAutoStartEnabled
+    public bool IsAutoStartEnabled => _settings.IsAutoStartEnabled;
+
+    public ICommand ToggleAutoStartCommand { get; }
+
+    public void SetAutoStartEnabled(bool isEnabled)
     {
-        get => _settings.IsAutoStartEnabled;
-        set => Apply(_settings.IsAutoStartEnabled, value, next => _settings.IsAutoStartEnabled = next);
+        if (_settings.IsAutoStartEnabled == isEnabled)
+        {
+            return;
+        }
+
+        try
+        {
+            _service?.Apply(BuildRequest(isEnabled));
+            _settings.IsAutoStartEnabled = isEnabled;
+            _settingsStore.Save(_settings);
+            StatusText = _localization.GetString("Settings.AppBehavior.Applied");
+        }
+        catch (Exception exception)
+        {
+            StatusText = exception.Message;
+            AppLogger.Warning($"App behavior apply failed: {exception.Message}");
+        }
+
+        OnPropertyChanged(nameof(IsAutoStartEnabled));
     }
 
     public void RefreshFromSettings()
     {
         OnPropertyChanged(string.Empty);
-        _service?.Apply(BuildRequest());
     }
 
     public void Dispose()
@@ -117,11 +140,6 @@ public sealed class SettingsAppBehaviorViewModel : ViewModelBase, IDisposable
         assign(nextValue);
         try
         {
-            if (ShouldApplyPlatformBehavior(propertyName))
-            {
-                _service?.Apply(BuildRequest());
-            }
-
             _settingsStore.Save(_settings);
             StatusText = _localization.GetString("Settings.AppBehavior.Applied");
         }
@@ -135,17 +153,11 @@ public sealed class SettingsAppBehaviorViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(propertyName);
     }
 
-    private AppBehaviorApplicationRequest BuildRequest() => new(
+    private AppBehaviorApplicationRequest BuildRequest(bool isAutoStartEnabled) => new(
         _settings.IsSilentStartEnabled,
         _settings.IsMinimizeToTrayEnabled,
         _settings.IsLazyModeEnabled,
-        _settings.IsAutoStartEnabled);
-
-    private bool ShouldApplyPlatformBehavior(string? propertyName)
-    {
-        return propertyName == nameof(IsAutoStartEnabled)
-            || (propertyName == nameof(IsSilentStartEnabled) && _settings.IsAutoStartEnabled);
-    }
+        isAutoStartEnabled);
 
     private void OnLanguageChanged(object? sender, EventArgs e)
     {

--- a/tests/Stelliberty.Infrastructure.Tests/AutoStartEntryBuilderTests.cs
+++ b/tests/Stelliberty.Infrastructure.Tests/AutoStartEntryBuilderTests.cs
@@ -10,7 +10,6 @@ public sealed class AutoStartEntryBuilderTests
     {
         var xml = AutoStartEntryBuilder.WindowsScheduledTaskXml(
             @"C:\Program Files\Stelliberty\stelliberty.exe",
-            isSilentStartEnabled: true,
             userId: "S-1-5-21-test");
 
         Assert.Contains("<LogonTrigger>", xml);
@@ -23,9 +22,7 @@ public sealed class AutoStartEntryBuilderTests
     [Fact(DisplayName = "Windows scheduled task XML escapes path and omits silent argument")]
     public void WindowsScheduledTaskXmlEscapesPathAndOmitsSilentArgument()
     {
-        var xml = AutoStartEntryBuilder.WindowsScheduledTaskXml(
-            @"C:\A&B\stelliberty.exe",
-            isSilentStartEnabled: false);
+        var xml = AutoStartEntryBuilder.WindowsScheduledTaskXml(@"C:\A&B\stelliberty.exe");
 
         Assert.Contains(@"<Command>C:\A&amp;B\stelliberty.exe</Command>", xml);
         Assert.DoesNotContain("<Arguments>", xml);

--- a/tests/Stelliberty.Infrastructure.Tests/AutoStartEntryBuilderTests.cs
+++ b/tests/Stelliberty.Infrastructure.Tests/AutoStartEntryBuilderTests.cs
@@ -5,8 +5,8 @@ namespace Stelliberty.Infrastructure.Tests;
 
 public sealed class AutoStartEntryBuilderTests
 {
-    [Fact(DisplayName = "Windows scheduled task XML starts at logon with highest run level")]
-    public void WindowsScheduledTaskXmlStartsAtLogonWithHighestRunLevel()
+    [Fact(DisplayName = "Windows scheduled task XML starts after one second without elevating the app")]
+    public void WindowsScheduledTaskXmlStartsAfterOneSecondWithoutElevatingTheApp()
     {
         var xml = AutoStartEntryBuilder.WindowsScheduledTaskXml(
             @"C:\Program Files\Stelliberty\stelliberty.exe",
@@ -14,10 +14,10 @@ public sealed class AutoStartEntryBuilderTests
             userId: "S-1-5-21-test");
 
         Assert.Contains("<LogonTrigger>", xml);
-        Assert.Contains("<Delay>PT2S</Delay>", xml);
-        Assert.Contains("<RunLevel>HighestAvailable</RunLevel>", xml);
+        Assert.Contains("<Delay>PT1S</Delay>", xml);
+        Assert.Contains("<RunLevel>LeastPrivilege</RunLevel>", xml);
         Assert.Contains("<UserId>S-1-5-21-test</UserId>", xml);
-        Assert.Contains("<Arguments>--silent-start</Arguments>", xml);
+        Assert.DoesNotContain("<Arguments>", xml);
     }
 
     [Fact(DisplayName = "Windows scheduled task XML escapes path and omits silent argument")]

--- a/tests/Stelliberty.Infrastructure.Tests/FileSubscriptionStoreTests.cs
+++ b/tests/Stelliberty.Infrastructure.Tests/FileSubscriptionStoreTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Stelliberty.Domain.Subscriptions;
+using Stelliberty.Infrastructure.Subscriptions;
+using Xunit;
+
+namespace Stelliberty.Infrastructure.Tests;
+
+public sealed class FileSubscriptionStoreTests
+{
+    [Theory(DisplayName = "Subscription store recovers a missing or null list before saving")]
+    [InlineData("{}")]
+    [InlineData("{\"Subscriptions\":null}")]
+    public void SubscriptionStoreRecoversMissingOrNullListBeforeSaving(string listContent)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"stelliberty-subscriptions-{Guid.NewGuid():N}");
+        var directory = Path.Combine(root, "subscriptions");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "subscriptions_list.json"), listContent);
+
+        try
+        {
+            var store = new FileSubscriptionStore(root);
+            var subscription = new Subscription(
+                "demo",
+                "Demo",
+                "https://example.test/subscription",
+                IsLocalFile: false,
+                CreatedAt: DateTimeOffset.UnixEpoch);
+
+            store.Save(subscription, "proxies: []");
+
+            Assert.Equal("demo", Assert.Single(store.LoadSubscriptions()).Id);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact(DisplayName = "Subscription store writes strictly PascalCase fields")]
+    public void SubscriptionStoreWritesStrictlyPascalCaseFields()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"stelliberty-subscriptions-{Guid.NewGuid():N}");
+
+        try
+        {
+            var store = new FileSubscriptionStore(root);
+            var subscription = new Subscription(
+                "demo",
+                "Demo",
+                "https://example.test/subscription",
+                IsLocalFile: false,
+                CreatedAt: DateTimeOffset.UnixEpoch);
+
+            store.Save(subscription, "proxies: []");
+
+            using var document = JsonDocument.Parse(File.ReadAllText(
+                Path.Combine(root, "subscriptions", "subscriptions_list.json")));
+            var rootElement = document.RootElement;
+            var storedSubscription = Assert.Single(rootElement.GetProperty("Subscriptions").EnumerateArray());
+
+            Assert.False(rootElement.TryGetProperty("subscriptions", out _));
+            Assert.All(rootElement.EnumerateObject(), property => Assert.True(char.IsUpper(property.Name[0])));
+            Assert.All(storedSubscription.EnumerateObject(), property => Assert.True(char.IsUpper(property.Name[0])));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact(DisplayName = "Subscription store rejects lowercase persisted fields")]
+    public void SubscriptionStoreRejectsLowercasePersistedFields()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"stelliberty-subscriptions-{Guid.NewGuid():N}");
+        var directory = Path.Combine(root, "subscriptions");
+        var listPath = Path.Combine(directory, "subscriptions_list.json");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(listPath, "{\"subscriptions\":[]}");
+
+        try
+        {
+            var store = new FileSubscriptionStore(root);
+
+            Assert.Empty(store.LoadSubscriptions());
+            Assert.False(File.Exists(listPath));
+            Assert.True(File.Exists(listPath + ".corrupt"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Stelliberty.ProxyPage.Tests/ProxyPageViewModelTests.cs
+++ b/tests/Stelliberty.ProxyPage.Tests/ProxyPageViewModelTests.cs
@@ -633,6 +633,27 @@ public sealed class ProxyPageViewModelTests
         Assert.Equal(ProxyPageLayout.Horizontal, persisted);
     }
 
+    [Fact(DisplayName = "Sort mode persists across page recreation and config reload")]
+    public void SortModePersistsAcrossPageRecreationAndConfigReload()
+    {
+        var persisted = ProxyNodeSortMode.Default;
+        var page = new ProxyPageViewModel(persistSortMode: mode => persisted = mode);
+        page.LoadConfig(SampleConfig());
+
+        page.SetSortMode(ProxyNodeSortMode.Delay);
+        page.LoadConfig(SampleConfig());
+
+        Assert.Equal(ProxyNodeSortMode.Delay, page.SortMode);
+        Assert.Equal(["KR", "JP"], page.VisibleNodeRows.Select(row => row.Name));
+        Assert.Equal(ProxyNodeSortMode.Delay, persisted);
+
+        var recreated = new ProxyPageViewModel(initialSortMode: persisted);
+        recreated.LoadConfig(SampleConfig());
+
+        Assert.Equal(ProxyNodeSortMode.Delay, recreated.SortMode);
+        Assert.Equal(["KR", "JP"], recreated.VisibleNodeRows.Select(row => row.Name));
+    }
+
     [Fact(DisplayName = "Vertical group cards reflect visible groups collapsed by default")]
     public void VerticalGroupCardsReflectVisibleGroupsCollapsedByDefault()
     {

--- a/tests/Stelliberty.Settings.Tests/SettingsPageBusinessTests.cs
+++ b/tests/Stelliberty.Settings.Tests/SettingsPageBusinessTests.cs
@@ -56,7 +56,7 @@ public sealed class SettingsPageBusinessTests
         var viewModel = new SettingsAppBehaviorViewModel(settings, store, new FakeLocalizationService(), service);
 
         viewModel.IsLazyModeEnabled = true;
-        viewModel.IsAutoStartEnabled = true;
+        viewModel.SetAutoStartEnabled(true);
 
         Assert.Equal(2, store.SaveCount);
         Assert.Equal(1, service.ApplyCount);
@@ -73,13 +73,59 @@ public sealed class SettingsPageBusinessTests
         var service = new FakeAppBehaviorService { ShouldFail = true };
         var viewModel = new SettingsAppBehaviorViewModel(settings, store, new FakeLocalizationService(), service);
 
-        viewModel.IsAutoStartEnabled = true;
+        viewModel.SetAutoStartEnabled(true);
 
         Assert.False(settings.IsAutoStartEnabled);
         Assert.False(viewModel.IsAutoStartEnabled);
         Assert.Equal(0, store.SaveCount);
         Assert.Equal(1, service.ApplyCount);
         Assert.True(viewModel.IsStatusVisible);
+    }
+
+    [Fact(DisplayName = "App behavior keeps autostart enabled when disabling is denied")]
+    public void AppBehaviorKeepsAutoStartEnabledWhenDisablingIsDenied()
+    {
+        var settings = new AppSettings { IsAutoStartEnabled = true };
+        var store = new FakeSettingsStore(settings);
+        var service = new FakeAppBehaviorService { ShouldFail = true };
+        var viewModel = new SettingsAppBehaviorViewModel(settings, store, new FakeLocalizationService(), service);
+
+        viewModel.SetAutoStartEnabled(false);
+
+        Assert.True(settings.IsAutoStartEnabled);
+        Assert.True(viewModel.IsAutoStartEnabled);
+        Assert.Equal(0, store.SaveCount);
+        Assert.Equal(1, service.ApplyCount);
+    }
+
+    [Fact(DisplayName = "App behavior refresh does not recreate platform startup entry")]
+    public void AppBehaviorRefreshDoesNotRecreatePlatformStartupEntry()
+    {
+        var settings = new AppSettings { IsAutoStartEnabled = true };
+        var store = new FakeSettingsStore(settings);
+        var service = new FakeAppBehaviorService();
+        var viewModel = new SettingsAppBehaviorViewModel(settings, store, new FakeLocalizationService(), service);
+
+        viewModel.RefreshFromSettings();
+
+        Assert.Equal(0, service.ApplyCount);
+        Assert.Equal(0, store.SaveCount);
+        Assert.True(viewModel.IsAutoStartEnabled);
+    }
+
+    [Fact(DisplayName = "Changing silent start does not reconfigure platform startup")]
+    public void ChangingSilentStartDoesNotReconfigurePlatformStartup()
+    {
+        var settings = new AppSettings { IsAutoStartEnabled = true };
+        var store = new FakeSettingsStore(settings);
+        var service = new FakeAppBehaviorService();
+        var viewModel = new SettingsAppBehaviorViewModel(settings, store, new FakeLocalizationService(), service);
+
+        viewModel.IsSilentStartEnabled = true;
+
+        Assert.Equal(0, service.ApplyCount);
+        Assert.True(settings.IsSilentStartEnabled);
+        Assert.Equal(1, store.SaveCount);
     }
 
     [Fact(DisplayName = "Core config port changes request runtime refresh")]


### PR DESCRIPTION
## Summary

- Correct Windows autostart state handling and startup timing
- Persist proxy sorting and smooth horizontal group scrolling
- Preserve portable data across macOS and Linux application replacements
- Stabilize subscription persistence and macOS localization metadata
- Add installer replacement simulations for Linux, AppImage, and macOS

## Validation

- Platform verification workflow passed before the version bump
- Installer data persistence simulations passed on Linux x64, Linux arm64, macOS x64, and macOS arm64
- Local infrastructure tests and Windows development build passed
- Repository privacy scan passed