### PR TITLE
fix(proxy): 修复节点定位后重复回跳

### DIFF
--- a/src/Stelliberty.Desktop/Views/ProxyView.axaml.cs
+++ b/src/Stelliberty.Desktop/Views/ProxyView.axaml.cs
@@ -15,6 +15,7 @@ public sealed partial class ProxyView : UserControl
     // 单格滚轮约移动一个分组标签，触控板增量仍按比例生效。
     private const double GroupTabsWheelStep = 72;
     private ProxyPageViewModel? _attachedViewModel;
+    private int _handledLocateNodeRequestId;
     private int _handledScrollToTopRequestId;
     private double _savedNodeScrollOffset;
 
@@ -62,6 +63,7 @@ public sealed partial class ProxyView : UserControl
         DetachViewModel();
 
         _attachedViewModel = ProxyPageRoot.DataContext as ProxyPageViewModel;
+        _handledLocateNodeRequestId = _attachedViewModel?.LocateNodeRequestId ?? 0;
         _handledScrollToTopRequestId = 0;
         if (_attachedViewModel is not null)
         {
@@ -87,9 +89,14 @@ public sealed partial class ProxyView : UserControl
             return;
         }
 
-        if (args.PropertyName == nameof(ProxyPageViewModel.LocatedNodeName) && viewModel.LocatedNodeName is not null)
+        if (args.PropertyName == nameof(ProxyPageViewModel.LocateNodeRequestId)
+            && viewModel.LocateNodeRequestId != _handledLocateNodeRequestId)
         {
-            ScrollToNode(viewModel.LocatedNodeName);
+            _handledLocateNodeRequestId = viewModel.LocateNodeRequestId;
+            if (viewModel.LocatedNodeName is not null)
+            {
+                ScrollToNode(viewModel.LocatedNodeName);
+            }
         }
 
         if (args.PropertyName == nameof(ProxyPageViewModel.ScrollToTopRequestId)

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -45,6 +45,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private readonly Dictionary<string, ProxyNodeRowViewModel> _nodeRowsByName = new(StringComparer.Ordinal);
     private string? _lastSelectedNodeName;
     private string? _locatedNodeName;
+    private int _locateNodeRequestId;
     private ProxyChangeRequest? _lastChangeRequest;
     private CancellationTokenSource? _batchDelayTestCancellation;
     private CancellationTokenSource? _singleDelayTestCancellation;
@@ -211,6 +212,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public string? LocatedNodeName => _locatedNodeName;
 
+    public int LocateNodeRequestId => _locateNodeRequestId;
+
     public ProxyChangeRequest? LastChangeRequest => _lastChangeRequest;
 
     public bool ShouldCloseConnectionsAfterSelection => _shouldCloseConnectionsAfterSelection;
@@ -266,6 +269,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         _batchDelayTestedNodeNames.Clear();
         _lastSelectedNodeName = null;
         _locatedNodeName = null;
+        _locateNodeRequestId = 0;
         _hasScrolledToTop = false;
         _scrollToTopRequestId = 0;
         _lastChangeRequest = null;
@@ -691,7 +695,14 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public void LocateSelectedNode()
     {
-        _locatedNodeName = _selectedGroup?.DisplaySelectionName;
+        var nodeName = _selectedGroup?.DisplaySelectionName;
+        if (string.IsNullOrWhiteSpace(nodeName))
+        {
+            return;
+        }
+
+        _locatedNodeName = nodeName;
+        _locateNodeRequestId++;
         RaiseProxyStateChanged();
     }
 
@@ -787,6 +798,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(SearchKeyword));
         OnPropertyChanged(nameof(LastSelectedNodeName));
         OnPropertyChanged(nameof(LocatedNodeName));
+        OnPropertyChanged(nameof(LocateNodeRequestId));
         OnPropertyChanged(nameof(LastChangeRequest));
         OnPropertyChanged(nameof(ShouldCloseConnectionsAfterSelection));
         OnPropertyChanged(nameof(HasScrolledToTop));


### PR DESCRIPTION
## 修改说明

- 将节点定位建模为一次性请求，避免被后续状态刷新重复执行。
- 在代理页面 ViewModel 中增加定位请求编号。
- 代理视图仅消费一次新的定位请求，后台选择同步不再覆盖用户手动滚动的位置。

## 验证情况

- `git diff --check` 已通过。
- 当前环境仅安装 .NET SDK 8.0.421，而项目目标框架为 .NET 11，因此无法执行 Desktop 构建，错误为 `NETSDK1045`。
- 按要求未新增或修改测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)