### PR TITLE
chore: release v2.0.9

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
-- Added an application behavior option to show or hide the live frame rate in the title bar, enabled by default.
+- Proxy delay tests once again show a rotating circular indicator instead of an ellipsis.
 
 ---
 
-- 新增在标题栏显示或隐藏实时帧率的应用行为选项，并默认开启。
+- 代理延迟测试重新显示旋转圆环，不再使用省略号。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.8</AppVersion>
+    <AppVersion>2.0.9</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/src/Stelliberty.Desktop/Styles/ProxyStyles.axaml
+++ b/src/Stelliberty.Desktop/Styles/ProxyStyles.axaml
@@ -1,5 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
         x:CompileBindings="True">
 
   <Style Selector="Button.proxy-group-tab">
@@ -105,17 +106,28 @@
     <Setter Property="Opacity" Value="0.72" />
   </Style>
 
-  <Style Selector="TextBlock.delay-badge.testing">
+  <Style Selector="iconPacks|PackIconMingCuteIcons.delay-spinner">
+    <Setter Property="Width" Value="16" />
+    <Setter Property="Height" Value="16" />
     <Setter Property="Foreground" Value="{DynamicResource AppAccentBrush}" />
+    <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
+      </Transitions>
+    </Setter>
     <Style.Animations>
-      <Animation Duration="0:0:0.8" IterationCount="Infinite" Easing="SineEaseInOut">
+      <Animation Duration="0:0:0.8" IterationCount="Infinite" Easing="LinearEasing">
         <KeyFrame Cue="0%">
-          <Setter Property="Opacity" Value="0.35" />
+          <Setter Property="RotateTransform.Angle" Value="0" />
         </KeyFrame>
         <KeyFrame Cue="100%">
-          <Setter Property="Opacity" Value="1" />
+          <Setter Property="RotateTransform.Angle" Value="360" />
         </KeyFrame>
       </Animation>
     </Style.Animations>
+  </Style>
+  <Style Selector="Button.delay-test-button:pointerover iconPacks|PackIconMingCuteIcons.delay-spinner">
+    <Setter Property="Opacity" Value="0.7" />
   </Style>
 </Styles>

--- a/src/Stelliberty.Desktop/Views/ProxyView.axaml
+++ b/src/Stelliberty.Desktop/Views/ProxyView.axaml
@@ -205,11 +205,20 @@
                           Margin="0,0,11,9"
                           Command="{Binding #ProxyPageRoot.((vm:ProxyPageViewModel)DataContext).TestNodeDelayCommand}"
                           CommandParameter="{Binding Name}">
-                    <TextBlock Classes="delay-badge"
-                               Classes.testing="{Binding IsDelayTesting}"
-                               Tag="{Binding DelayLevel}"
-                               Text="{Binding DisplayDelayText}"
-                               VerticalAlignment="Center" />
+                    <Panel Height="18">
+                      <TextBlock Classes="delay-badge"
+                                 AutomationProperties.AutomationId="{Binding DelayAutomationId}"
+                                 Tag="{Binding DelayLevel}"
+                                 IsVisible="{Binding !IsDelayTesting}"
+                                 Text="{Binding DelayText}"
+                                 VerticalAlignment="Center" />
+                      <iconPacks:PackIconMingCuteIcons Classes="delay-spinner"
+                                                        AutomationProperties.AutomationId="{Binding DelayTestingAutomationId}"
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        IsVisible="{Binding IsDelayTesting}"
+                                                        Kind="LoadingFill" />
+                    </Panel>
                   </Button>
                 </Grid>
               </Border>
@@ -325,11 +334,20 @@
                                       Margin="0,0,11,9"
                                       Command="{Binding #ProxyPageRoot.((vm:ProxyPageViewModel)DataContext).TestNodeDelayCommand}"
                                       CommandParameter="{Binding Name}">
-                                <TextBlock Classes="delay-badge"
-                                           Classes.testing="{Binding IsDelayTesting}"
-                                           Tag="{Binding DelayLevel}"
-                                           Text="{Binding DisplayDelayText}"
-                                           VerticalAlignment="Center" />
+                                <Panel Height="18">
+                                  <TextBlock Classes="delay-badge"
+                                             AutomationProperties.AutomationId="{Binding DelayAutomationId}"
+                                             Tag="{Binding DelayLevel}"
+                                             IsVisible="{Binding !IsDelayTesting}"
+                                             Text="{Binding DelayText}"
+                                             VerticalAlignment="Center" />
+                                  <iconPacks:PackIconMingCuteIcons Classes="delay-spinner"
+                                                                    AutomationProperties.AutomationId="{Binding DelayTestingAutomationId}"
+                                                                    HorizontalAlignment="Center"
+                                                                    VerticalAlignment="Center"
+                                                                    IsVisible="{Binding IsDelayTesting}"
+                                                                    Kind="LoadingFill" />
+                                </Panel>
                               </Button>
                             </Grid>
                           </Border>

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyNodeRowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyNodeRowViewModel.cs
@@ -29,6 +29,7 @@ public sealed class ProxyNodeRowViewModel : ViewModelBase
     public string RowAutomationId => $"Proxy.Node.{Name}";
     public string DelayAutomationId => $"Proxy.Node.{Name}.DelayText";
     public string TestDelayAutomationId => $"Proxy.Node.{Name}.TestDelayButton";
+    public string DelayTestingAutomationId => $"Proxy.Node.{Name}.DelaySpinner";
     public string SelectAutomationId => $"Proxy.Node.{Name}.SelectButton";
 
     public string Type => _node.Type;
@@ -58,7 +59,6 @@ public sealed class ProxyNodeRowViewModel : ViewModelBase
         {
             if (SetProperty(ref _isDelayTesting, value))
             {
-                OnPropertyChanged(nameof(DisplayDelayText));
                 OnPropertyChanged(nameof(DelayState));
             }
         }
@@ -70,8 +70,6 @@ public sealed class ProxyNodeRowViewModel : ViewModelBase
         < 0 => "-1 ms",
         _ => $"{_node.Delay} ms"
     };
-
-    public string DisplayDelayText => IsDelayTesting ? "..." : DelayText;
 
     public string DelayState => IsDelayTesting
         ? "testing"
@@ -100,7 +98,6 @@ public sealed class ProxyNodeRowViewModel : ViewModelBase
             if (delayChanged)
             {
                 OnPropertyChanged(nameof(DelayText));
-                OnPropertyChanged(nameof(DisplayDelayText));
                 OnPropertyChanged(nameof(DelayState));
                 OnPropertyChanged(nameof(DelayLevel));
             }
@@ -116,7 +113,6 @@ public sealed class ProxyNodeRowViewModel : ViewModelBase
     {
         _node = _node with { Delay = delay };
         OnPropertyChanged(nameof(DelayText));
-        OnPropertyChanged(nameof(DisplayDelayText));
         OnPropertyChanged(nameof(DelayState));
         OnPropertyChanged(nameof(DelayLevel));
         IsDelayTesting = false;


### PR DESCRIPTION
﻿## Summary
- Restore the rotating circular indicator for proxy delay tests
- Publish the v2.0.9 release summary

## Validation
- `python scripts/test.py proxy-page` (30 passed)
- Packaged Debug build completed successfully
