### PR TITLE
fix(subscription): improve remote download compatibility

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,7 @@
-- Proxy delay tests once again show a rotating circular indicator instead of an ellipsis.
+- Remote subscriptions now work with more restrictive download services and reject HTML error pages without exposing subscription details.
+- Rapid sidebar clicks no longer interrupt page navigation.
 
 ---
 
-- 代理延迟测试重新显示旋转圆环，不再使用省略号。
+- 远程订阅现在可兼容限制更严格的下载服务，并会在不泄露订阅信息的情况下拒绝 HTML 错误页面。
+- 快速点击侧栏时不再打断页面切换。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.9</AppVersion>
+    <AppVersion>2.0.10</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/src/Stelliberty.Infrastructure/Subscriptions/HttpRemoteSubscriptionDownloader.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/HttpRemoteSubscriptionDownloader.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Settings;
 using Stelliberty.Application.Subscriptions;
@@ -9,6 +11,13 @@ namespace Stelliberty.Infrastructure.Subscriptions;
 
 public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownloader
 {
+    private const int FailureHtmlPrefixLength = 4096;
+    private const int MaxDiagnosticValueLength = 200;
+    private static readonly Regex HtmlTitleRegex = new(
+        @"<title[^>]*>(?<title>.*?)</title>",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
     private readonly Func<(string Host, int Port)> _coreProxyEndpointProvider;
 
     public HttpRemoteSubscriptionDownloader(string coreProxyHost = "127.0.0.1", int coreProxyPort = AppSettings.DefaultMixedPort)
@@ -50,13 +59,122 @@ public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownlo
             message.Headers.UserAgent.ParseAdd(request.UserAgent);
         }
 
-        using var response = await client.SendAsync(message, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        AppLogger.Info($"Remote subscription downloaded: {request.SourceLocation}");
-        var content = await HttpContentTextReader.ReadAsStringAsync(response.Content, cancellationToken);
-        var trafficInfo = response.Headers.TryGetValues("subscription-userinfo", out var values)
-            ? SubscriptionTrafficInfo.ParseHeader(values.FirstOrDefault() ?? string.Empty)
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.SendAsync(message, cancellationToken);
+        }
+        catch (HttpRequestException exception)
+        {
+            throw new HttpRequestException(
+                BuildTransportFailureMessage(request, exception),
+                exception,
+                exception.StatusCode);
+        }
+
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw await CreateResponseFailureExceptionAsync(request, response, cancellationToken);
+            }
+
+            AppLogger.Info($"Remote subscription downloaded: {request.SourceLocation}");
+            var content = await HttpContentTextReader.ReadAsStringAsync(response.Content, cancellationToken);
+            var trafficInfo = response.Headers.TryGetValues("subscription-userinfo", out var values)
+                ? SubscriptionTrafficInfo.ParseHeader(values.FirstOrDefault() ?? string.Empty)
+                : null;
+            return new RemoteSubscriptionDownloadResult(content, trafficInfo);
+        }
+    }
+
+    private static async Task<HttpRequestException> CreateResponseFailureExceptionAsync(
+        RemoteSubscriptionDownloadRequest request,
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        var finalUri = response.RequestMessage?.RequestUri;
+        var requestedUri = Uri.TryCreate(request.SourceLocation, UriKind.Absolute, out var sourceUri) ? sourceUri : null;
+        var wasRedirected = requestedUri is not null
+            && finalUri is not null
+            && Uri.Compare(requestedUri, finalUri, UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) != 0;
+        var title = await TryReadHtmlTitleAsync(response.Content, cancellationToken);
+        var contentType = response.Content.Headers.ContentType?.ToString() ?? "unknown";
+        var contentLength = response.Content.Headers.ContentLength?.ToString() ?? "unknown";
+        var server = response.Headers.Server.ToString();
+        var details = new List<string>
+        {
+            $"HTTP {(int)response.StatusCode} {SanitizeDiagnosticValue(response.ReasonPhrase, "unknown")}",
+            $"type={SanitizeDiagnosticValue(contentType, "unknown")}",
+            $"host={SanitizeDiagnosticValue(finalUri?.Host, "unknown")}",
+            $"redirected={wasRedirected}",
+            $"proxy={request.ProxyMode}",
+            $"length={contentLength}"
+        };
+        if (!string.IsNullOrWhiteSpace(server))
+        {
+            details.Add($"server={SanitizeDiagnosticValue(server, "unknown")}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(title))
+        {
+            details.Add($"title={title}");
+        }
+
+        return new HttpRequestException(
+            $"Subscription download request failed: {string.Join("; ", details)}",
+            null,
+            response.StatusCode);
+    }
+
+    private static async Task<string?> TryReadHtmlTitleAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(content.Headers.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
+        var buffer = new byte[FailureHtmlPrefixLength];
+        var length = 0;
+        while (length < buffer.Length)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(length), cancellationToken);
+            if (read == 0)
+            {
+                break;
+            }
+
+            length += read;
+        }
+
+        if (length == 0)
+        {
+            return null;
+        }
+
+        var match = HtmlTitleRegex.Match(Encoding.UTF8.GetString(buffer, 0, length));
+        return match.Success
+            ? SanitizeDiagnosticValue(WebUtility.HtmlDecode(match.Groups["title"].Value), string.Empty)
             : null;
-        return new RemoteSubscriptionDownloadResult(content, trafficInfo);
+    }
+
+    private static string BuildTransportFailureMessage(RemoteSubscriptionDownloadRequest request, HttpRequestException exception)
+    {
+        var host = Uri.TryCreate(request.SourceLocation, UriKind.Absolute, out var sourceUri)
+            ? sourceUri.Host
+            : "unknown";
+        return $"Subscription download request could not be completed: host={SanitizeDiagnosticValue(host, "unknown")}; proxy={request.ProxyMode}; error={SanitizeDiagnosticValue(exception.Message, "unknown")}";
+    }
+
+    private static string SanitizeDiagnosticValue(string? value, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var trimmed = value.Trim();
+        return AppLogSanitizer.Sanitize(trimmed.Length <= MaxDiagnosticValueLength ? trimmed : trimmed[..MaxDiagnosticValueLength]);
     }
 }

--- a/src/Stelliberty.Infrastructure/Subscriptions/HttpRemoteSubscriptionDownloader.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/HttpRemoteSubscriptionDownloader.cs
@@ -1,6 +1,5 @@
 using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
+using System.Net.Http.Headers;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Settings;
 using Stelliberty.Application.Subscriptions;
@@ -11,12 +10,8 @@ namespace Stelliberty.Infrastructure.Subscriptions;
 
 public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownloader
 {
-    private const int FailureHtmlPrefixLength = 4096;
-    private const int MaxDiagnosticValueLength = 200;
-    private static readonly Regex HtmlTitleRegex = new(
-        @"<title[^>]*>(?<title>.*?)</title>",
-        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant,
-        TimeSpan.FromSeconds(1));
+    private const int MaxSubscriptionContentBytes = 10 * 1024 * 1024;
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(10);
 
     private readonly Func<(string Host, int Port)> _coreProxyEndpointProvider;
 
@@ -32,7 +27,10 @@ public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownlo
 
     public async Task<RemoteSubscriptionDownloadResult> DownloadAsync(RemoteSubscriptionDownloadRequest request, CancellationToken cancellationToken = default)
     {
-        using var handler = new HttpClientHandler();
+        using var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli
+        };
         if (request.ProxyMode == SubscriptionUpdateProxyMode.Direct)
         {
             handler.UseProxy = false;
@@ -51,24 +49,35 @@ public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownlo
 
         using var client = new HttpClient(handler)
         {
-            Timeout = TimeSpan.FromSeconds(30)
+            Timeout = Timeout.InfiniteTimeSpan
         };
-        using var message = new HttpRequestMessage(HttpMethod.Get, request.SourceLocation);
-        if (!string.IsNullOrWhiteSpace(request.UserAgent))
+        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCancellation.CancelAfter(DownloadTimeout);
+        var requestCancellationToken = timeoutCancellation.Token;
+        using var message = new HttpRequestMessage(HttpMethod.Get, request.SourceLocation)
         {
-            message.Headers.UserAgent.ParseAdd(request.UserAgent);
-        }
+            Version = HttpVersion.Version11,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact
+        };
+        message.Headers.UserAgent.ParseAdd(SubscriptionDefaults.NormalizeUserAgent(request.UserAgent));
+        message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/yaml"));
+        message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/yaml"));
+        message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-yaml"));
+        message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+        message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*", 0.1));
+        message.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
+        message.Headers.Pragma.Add(new NameValueHeaderValue("no-cache"));
 
         HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(message, cancellationToken);
+            response = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, requestCancellationToken);
         }
         catch (HttpRequestException exception)
         {
             throw new HttpRequestException(
                 BuildTransportFailureMessage(request, exception),
-                exception,
+                null,
                 exception.StatusCode);
         }
 
@@ -76,50 +85,51 @@ public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownlo
         {
             if (!response.IsSuccessStatusCode)
             {
-                throw await CreateResponseFailureExceptionAsync(request, response, cancellationToken);
+                throw CreateResponseFailureException(request, response);
             }
 
-            AppLogger.Info($"Remote subscription downloaded: {request.SourceLocation}");
-            var content = await HttpContentTextReader.ReadAsStringAsync(response.Content, cancellationToken);
+            await response.Content.LoadIntoBufferAsync(MaxSubscriptionContentBytes, requestCancellationToken);
+            var content = await HttpContentTextReader.ReadAsStringAsync(response.Content, requestCancellationToken);
+            if (LooksLikeHtmlDocument(content))
+            {
+                throw CreateUnexpectedHtmlResponseException(request, response);
+            }
+
             var trafficInfo = response.Headers.TryGetValues("subscription-userinfo", out var values)
                 ? SubscriptionTrafficInfo.ParseHeader(values.FirstOrDefault() ?? string.Empty)
                 : null;
+            AppLogger.Info($"Remote subscription downloaded: proxy={request.ProxyMode}");
             return new RemoteSubscriptionDownloadResult(content, trafficInfo);
         }
     }
 
-    private static async Task<HttpRequestException> CreateResponseFailureExceptionAsync(
+    private static HttpRequestException CreateUnexpectedHtmlResponseException(
         RemoteSubscriptionDownloadRequest request,
-        HttpResponseMessage response,
-        CancellationToken cancellationToken)
+        HttpResponseMessage response)
+    {
+        return new HttpRequestException(
+            $"Subscription download returned an HTML page instead of a configuration: HTTP {(int)response.StatusCode}; proxy={request.ProxyMode}",
+            null,
+            response.StatusCode);
+    }
+
+    private static HttpRequestException CreateResponseFailureException(
+        RemoteSubscriptionDownloadRequest request,
+        HttpResponseMessage response)
     {
         var finalUri = response.RequestMessage?.RequestUri;
         var requestedUri = Uri.TryCreate(request.SourceLocation, UriKind.Absolute, out var sourceUri) ? sourceUri : null;
         var wasRedirected = requestedUri is not null
             && finalUri is not null
             && Uri.Compare(requestedUri, finalUri, UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) != 0;
-        var title = await TryReadHtmlTitleAsync(response.Content, cancellationToken);
-        var contentType = response.Content.Headers.ContentType?.ToString() ?? "unknown";
         var contentLength = response.Content.Headers.ContentLength?.ToString() ?? "unknown";
-        var server = response.Headers.Server.ToString();
         var details = new List<string>
         {
-            $"HTTP {(int)response.StatusCode} {SanitizeDiagnosticValue(response.ReasonPhrase, "unknown")}",
-            $"type={SanitizeDiagnosticValue(contentType, "unknown")}",
-            $"host={SanitizeDiagnosticValue(finalUri?.Host, "unknown")}",
+            $"HTTP {(int)response.StatusCode}",
             $"redirected={wasRedirected}",
             $"proxy={request.ProxyMode}",
             $"length={contentLength}"
         };
-        if (!string.IsNullOrWhiteSpace(server))
-        {
-            details.Add($"server={SanitizeDiagnosticValue(server, "unknown")}");
-        }
-
-        if (!string.IsNullOrWhiteSpace(title))
-        {
-            details.Add($"title={title}");
-        }
 
         return new HttpRequestException(
             $"Subscription download request failed: {string.Join("; ", details)}",
@@ -127,54 +137,55 @@ public sealed class HttpRemoteSubscriptionDownloader : IRemoteSubscriptionDownlo
             response.StatusCode);
     }
 
-    private static async Task<string?> TryReadHtmlTitleAsync(HttpContent content, CancellationToken cancellationToken)
+    private static bool LooksLikeHtmlDocument(string content)
     {
-        if (!string.Equals(content.Headers.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
+        var prefix = TrimHtmlPreamble(content.AsSpan());
+        return prefix.StartsWith("<!doctype html", StringComparison.OrdinalIgnoreCase)
+            || prefix.StartsWith("<html", StringComparison.OrdinalIgnoreCase)
+            || prefix.StartsWith("<head", StringComparison.OrdinalIgnoreCase)
+            || prefix.StartsWith("<body", StringComparison.OrdinalIgnoreCase);
+    }
 
-        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
-        var buffer = new byte[FailureHtmlPrefixLength];
-        var length = 0;
-        while (length < buffer.Length)
+    private static ReadOnlySpan<char> TrimHtmlPreamble(ReadOnlySpan<char> content)
+    {
+        while (true)
         {
-            var read = await stream.ReadAsync(buffer.AsMemory(length), cancellationToken);
-            if (read == 0)
+            content = content.TrimStart();
+            while (!content.IsEmpty && content[0] is '\uFEFF' or '\u200B')
             {
-                break;
+                content = content[1..].TrimStart();
             }
 
-            length += read;
-        }
+            if (content.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase))
+            {
+                var declarationEnd = content.IndexOf("?>", StringComparison.Ordinal);
+                if (declarationEnd < 0)
+                {
+                    return content;
+                }
 
-        if (length == 0)
-        {
-            return null;
-        }
+                content = content[(declarationEnd + 2)..];
+                continue;
+            }
 
-        var match = HtmlTitleRegex.Match(Encoding.UTF8.GetString(buffer, 0, length));
-        return match.Success
-            ? SanitizeDiagnosticValue(WebUtility.HtmlDecode(match.Groups["title"].Value), string.Empty)
-            : null;
+            if (content.StartsWith("<!--", StringComparison.Ordinal))
+            {
+                var commentEnd = content.IndexOf("-->", StringComparison.Ordinal);
+                if (commentEnd < 0)
+                {
+                    return content;
+                }
+
+                content = content[(commentEnd + 3)..];
+                continue;
+            }
+
+            return content;
+        }
     }
 
     private static string BuildTransportFailureMessage(RemoteSubscriptionDownloadRequest request, HttpRequestException exception)
     {
-        var host = Uri.TryCreate(request.SourceLocation, UriKind.Absolute, out var sourceUri)
-            ? sourceUri.Host
-            : "unknown";
-        return $"Subscription download request could not be completed: host={SanitizeDiagnosticValue(host, "unknown")}; proxy={request.ProxyMode}; error={SanitizeDiagnosticValue(exception.Message, "unknown")}";
-    }
-
-    private static string SanitizeDiagnosticValue(string? value, string fallback)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return fallback;
-        }
-
-        var trimmed = value.Trim();
-        return AppLogSanitizer.Sanitize(trimmed.Length <= MaxDiagnosticValueLength ? trimmed : trimmed[..MaxDiagnosticValueLength]);
+        return $"Subscription download request could not be completed: proxy={request.ProxyMode}; error={exception.HttpRequestError}";
     }
 }

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
@@ -49,7 +49,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     private long _lastNavTickMs;
     // 导航节流只覆盖双击窗口，不影响正常页面切换。
-    private const long NavThrottleMs = 50;
+    private const long NavThrottleMs = 150;
     private const int CoreLogFlushBatchSize = 4;
     private const int ToastMessageMaxLength = 72;
     private static readonly TimeSpan CoreLogFlushDelay = TimeSpan.FromMilliseconds(700);

--- a/tests/Stelliberty.Shell.Tests/MainWindowShellTests.cs
+++ b/tests/Stelliberty.Shell.Tests/MainWindowShellTests.cs
@@ -318,7 +318,8 @@ public sealed class MainWindowShellTests
         try
         {
             await provider.Started.Task.WaitAsync(AsyncTestTimeout);
-            await Task.Delay(60);
+            // 等待导航节流结束，确保切页触发取消链路。
+            await Task.Delay(200);
             viewModel.ShowHomeCommand.Execute(null);
             await WaitUntilAsync(() => provider.CancellationObserved);
             provider.Release.TrySetResult();


### PR DESCRIPTION
## Summary

- Improve remote subscription compatibility with strict CDN services
- Reject HTML error pages without exposing subscription details
- Bound subscription downloads to 10 seconds and 10 MiB after decompression
- Increase sidebar navigation throttling and bump the app to v2.0.10

## Validation

- `python scripts/test.py infrastructure` (19 tests passed)
- `python scripts/test.py shell-navigation` (44 tests passed)
- `cargo fmt`
- `dotnet format Stelliberty.slnx --no-restore`
- Reachable commit and diff privacy scan passed

Related to #90