### PR TITLE
chore: release v2.0.16

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
-- During batch proxy delay tests, each proxy now shows its testing state only when its test actually begins.
+- Beta downloads now appear only after every package has finished uploading.
 
 ---
 
-- 批量代理测速时，每个代理会在实际开始测速后才显示测速状态。
+- Beta 下载现在会在所有安装包上传完成后再显示。

--- a/.github/docs/README.zh-CN.md
+++ b/.github/docs/README.zh-CN.md
@@ -100,9 +100,9 @@ Stelliberty 是跨平台桌面代理客户端，覆盖 Windows、Linux 与 macOS
 
 <sub>[↑ 回到导航](#导航)</sub>
 
-### 安装 .NET 11 运行时
+### 安装后无法启动或启动无响应？
 
-运行 Stelliberty 前，请先安装 .NET 11 运行时：
+请先安装 .NET 11 运行时，然后重新启动 Stelliberty：
 
 - 通用：[微软官方下载](https://dotnet.microsoft.com/download/dotnet/11.0)
 - Arch Linux 及其衍生发行版：AUR 包 [`dotnet-core-preview-bin`](https://aur.archlinux.org/packages/dotnet-core-preview-bin)

--- a/.github/scripts/simulation_tests.py
+++ b/.github/scripts/simulation_tests.py
@@ -154,7 +154,10 @@ class SimulationTests:
         self.step("Restore outbound mode to rule", lambda: self.require("home.set_outbound rule", contains=["outbound=Rule"]))
         self.step("Switch takeover tab to system proxy", lambda: self.require("home.select_takeover proxy", contains=["takeover=proxy"]))
         self.step("Switch takeover tab to TUN", lambda: self.require("home.select_takeover tun", contains=["takeover=tun"]))
-        self.step("Verify TUN is disabled", lambda: self.require("home.set_tun off", contains=["tun=false"]))
+        self.step("Verify TUN boolean input", lambda: (
+            self.require_error("home.set_tun off", contains=["Invalid boolean value: off"]),
+            self.require("home.set_tun false", contains=["tun=false"]),
+        ))
         self.step("Reset traffic statistics", lambda: self.require("home.reset_traffic", contains=["upload=", "download="]))
         self.step("Restart core and wait for recovery", lambda: (
             self.require("home.restart_core"),
@@ -268,7 +271,7 @@ class SimulationTests:
         self.open_page("settings/data-management", "Settings.WebDavEnableToggle")
         self.require("settings.data_management.webdav_keys", contains=["enabled", "url", "retention-count"])
         self.require("settings.data_management.webdav_state", contains=["webdavEnabled=", "webdavBusy=false"])
-        self.require("settings.data_management.webdav_set enabled off", contains=["webdavEnabled=false"])
+        self.require("settings.data_management.webdav_set enabled false", contains=["webdavEnabled=false"])
         self.require("settings.data_management.webdav_set url https://webdav.example/dav", contains=["webdavUrlSet=true"])
         self.require("settings.data_management.webdav_set username ci-user", contains=["webdavUserSet=true"])
         self.require("settings.data_management.webdav_set password ci-password", contains=["webdavUserSet=true"])
@@ -330,6 +333,18 @@ class SimulationTests:
             if expected not in response:
                 raise SimulationTestError(f"{command} missing expected fragment {expected!r}, actual {response!r}")
 
+        return response
+
+    def require_error(self, command: str, *, contains: list[str]) -> str:
+        response = self.raw_command(command)
+        if not response.startswith("ERR "):
+            raise SimulationTestError(f"{command} expected an error, actual {response!r}")
+
+        for expected in contains:
+            if expected not in response:
+                raise SimulationTestError(f"{command} missing expected fragment {expected!r}, actual {response!r}")
+
+        self.print_command(command, response)
         return response
 
     def wait_for(self, command: str, *, contains: list[str], timeout: float = 60, interval: float = 1) -> str:

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -342,7 +342,7 @@ jobs:
           path: |
             build/*.zip
             build/packages/*
-          if-no-files-found: warn
+          if-no-files-found: error
 
   release:
     name: Publish beta to download repository
@@ -364,7 +364,8 @@ jobs:
           printf '%s' '${{ needs.prepare.outputs.release_notes }}' | base64 --decode > release_notes.md
           cat release_notes.md
 
-      - name: Publish to stelliberty
+      - name: Upload beta release draft
+        id: beta-release
         uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -382,7 +383,22 @@ jobs:
             artifacts/**/*.AppImage
             artifacts/**/*.dmg
             artifacts/**/*.pkg
-          draft: false
+          draft: true
           prerelease: true
           overwrite_files: true
+          fail_on_unmatched_files: true
           make_latest: false
+
+      - name: Publish beta release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.beta-release.outputs.id }}
+        run: |
+          set -euo pipefail
+
+          gh api \
+            --method PATCH \
+            "repos/Kindness-Kismet/stelliberty/releases/${RELEASE_ID}" \
+            -F draft=false \
+            -F prerelease=true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.15</AppVersion>
+    <AppVersion>2.0.16</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Config format is fully compatible with Clash Meta — see the [mihomo documentat
 
 <sub>[↑ Back to Navigation](#navigation)</sub>
 
-### Installing .NET 11 Runtime
+### App will not start or appears unresponsive after installation?
 
-Install the .NET 11 Runtime before running Stelliberty:
+Install the .NET 11 Runtime, then start Stelliberty again:
 
 - General: [Microsoft download](https://dotnet.microsoft.com/download/dotnet/11.0)
 - Arch Linux and derivatives: AUR package [`dotnet-core-preview-bin`](https://aur.archlinux.org/packages/dotnet-core-preview-bin)

--- a/src/Stelliberty.Desktop/Debug/Commands/Settings.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Settings.cs
@@ -640,7 +640,7 @@ internal static partial class DebugCommands
             var parts = SplitCommandTokens(spec["uwp_set ".Length..]);
             if (parts.Count < 2)
             {
-                throw new InvalidOperationException("settings.system_integration.uwp_set usage: settings.system_integration.uwp_set <package_family_name> <on|off>");
+                throw new InvalidOperationException("settings.system_integration.uwp_set usage: settings.system_integration.uwp_set <package_family_name> <true|false>");
             }
 
             if (!system.SetUwpItemSelected(parts[0], ParseBool(parts[1])))

--- a/src/Stelliberty.Desktop/Debug/Commands/Shared.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Shared.cs
@@ -166,11 +166,11 @@ internal static partial class DebugCommands
 
     private static bool ParseBool(string value)
     {
-        return value.ToLowerInvariant() switch
+        return value switch
         {
-            "1" or "true" or "yes" or "on" or "enabled" => true,
-            "0" or "false" or "no" or "off" or "disabled" => false,
-            _ => throw new InvalidOperationException($"Invalid boolean value: {value}")
+            "true" => true,
+            "false" => false,
+            _ => throw new InvalidOperationException($"Invalid boolean value: {value}. Expected true or false.")
         };
     }
 }

--- a/src/Stelliberty.Desktop/Debug/WindowScreenshot.cs
+++ b/src/Stelliberty.Desktop/Debug/WindowScreenshot.cs
@@ -22,7 +22,7 @@ internal static class WindowScreenshot
 
         using var bitmap = new RenderTargetBitmap(pixelSize, new Vector(96, 96));
         bitmap.Render(window);
-        bitmap.Save(screenshotPath);
+        bitmap.Save(screenshotPath, PngBitmapEncoderOptions.Default);
         AppLogger.Info($"Screenshot saved: {screenshotPath}");
     }
 

--- a/src/Stelliberty.Desktop/Stelliberty.Desktop.csproj
+++ b/src/Stelliberty.Desktop/Stelliberty.Desktop.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.0.5" PrivateAssets="All" Publish="True" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="12.1.1" PrivateAssets="All" Publish="True" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageReference Include="HotAvalonia" Version="3.1.3" PrivateAssets="All" Publish="True" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="HotAvalonia" Version="3.1.4" PrivateAssets="All" Publish="True" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="IconPacks.Avalonia.MingCuteIcons" Version="2.0.0-stelliberty.1" />
-    <PackageReference Include="Semi.Avalonia" Version="12.0.3" />
+    <PackageReference Include="Semi.Avalonia" Version="12.1.0" />
     <PackageReference Include="Semi.Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageReference Include="Semi.Avalonia.DataGrid" Version="12.0.0" />
-    <PackageReference Include="Semi.Avalonia.ColorPicker" Version="12.0.3" />
+    <PackageReference Include="Semi.Avalonia.DataGrid" Version="12.1.0" />
+    <PackageReference Include="Semi.Avalonia.ColorPicker" Version="12.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Upgrade the application version to 2.0.16
- Publish beta releases only after every artifact uploads successfully
- Include the latest runtime guidance, debug command cleanup, and Avalonia dependency updates

## Verification

- `cargo fmt`
- `dotnet format`
- `python scripts/test.py --all` (19 passed, 0 failed)