### PR TITLE
release: promote v2.0.18 to stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,11 +1,11 @@
-- Saved subscriptions and overrides are no longer cleared when a state file is temporarily locked or inaccessible.
-- Core restarts now stop when the previous core process cannot be confirmed closed.
-- Subscription and override operations no longer report false success, and canceled updates stay silent.
-- File picker failures now show a clear message while normal cancellation remains silent.
+- Excessive frame-rate drops when switching to the proxy page have been eliminated.
+- Service mode now stops the core correctly when the app exits.
+- The selected subscription and proxy choices now survive app restarts, core restarts, and service mode installation or removal.
+- The chain proxy dialog scrollbar is now aligned correctly.
 
 ---
 
-- 状态文件暂时被占用或无法访问时，已保存的订阅和覆写不再被清空。
-- 无法确认旧核心进程已关闭时，核心重启会立即停止。
-- 订阅和覆写操作不再虚假提示成功，主动取消更新时也不会提示失败。
-- 文件选择器异常时会显示明确提示，正常取消仍保持静默。
+- 彻底消除切换到代理页时的帧数过度下降。
+- 服务模式会在应用退出时正确停止核心。
+- 选中的订阅和代理节点现在会在应用重启、核心重启以及服务模式安装或卸载后保持不变。
+- 链式代理对话框的滚动条现已正确对齐。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.17</AppVersion>
+    <AppVersion>2.0.18</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/hub/src/capabilities/bootstrap.rs
+++ b/native/hub/src/capabilities/bootstrap.rs
@@ -24,7 +24,8 @@ struct HubInstance {
 static INSTANCE: OnceCell<HubInstance> = OnceCell::new();
 
 enum CoreTask {
-    Start,
+    StartConfirmed,
+    ActivateConfig(String),
     Stop,
 }
 
@@ -43,7 +44,8 @@ fn run_core_task(core: Arc<CoreRuntime>, task: CoreTask, timeout: Duration) -> a
     let (done_tx, done_rx) = std::sync::mpsc::channel();
     handle.spawn(async move {
         let result = match task {
-            CoreTask::Start => core.start_core().await,
+            CoreTask::StartConfirmed => core.start_core().await,
+            CoreTask::ActivateConfig(config) => core.start_core_with_config(config).await,
             CoreTask::Stop => core.stop_core().await,
         };
         let _ = done_tx.send(result);
@@ -81,10 +83,10 @@ impl BootstrapResult {
 
 fn run_bootstrap(
     pipe_name: String,
-    mihomo_path: PathBuf,
+    core_path: PathBuf,
     data_core_dir: PathBuf,
     user_data_dir: PathBuf,
-    mihomo_pipe: String,
+    core_pipe: String,
     bootstrap_yaml: String,
 ) -> anyhow::Result<HubInstance> {
     init_tracing();
@@ -93,14 +95,14 @@ fn run_bootstrap(
     let handle =
         runtime::handle().ok_or_else(|| anyhow::anyhow!("tokio runtime is not installed"))?;
 
-    let paths = HubPaths::new(user_data_dir, mihomo_path, data_core_dir);
+    let paths = HubPaths::new(user_data_dir, core_path, data_core_dir);
     paths.ensure_dirs()?;
 
     handle.block_on(async {
         let (events_tx, _) = broadcast::channel(128);
         let core = Arc::new(CoreRuntime::new(
             paths,
-            mihomo_pipe,
+            core_pipe,
             bootstrap_yaml,
             events_tx.clone(),
         )?);
@@ -129,24 +131,31 @@ fn run_bootstrap(
 #[ffi]
 pub fn hub_bootstrap(
     pipe_name: ffi::String,
-    mihomo_path: ffi::String,
+    core_path: ffi::String,
     data_core_dir: ffi::String,
     user_data_dir: ffi::String,
-    mihomo_pipe: ffi::String,
+    core_pipe: ffi::String,
     bootstrap_yaml: ffi::String,
 ) -> BootstrapResult {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if INSTANCE.get().is_some() {
-            // 首次 bootstrap 固定路径，后续调用只恢复核心运行。
-            return hub_start_core();
-        }
         let pipe = pipe_name.as_str().to_owned();
-        let mihomo = PathBuf::from(mihomo_path.as_str());
+        let core = PathBuf::from(core_path.as_str());
         let data_core = PathBuf::from(data_core_dir.as_str());
         let user_data = PathBuf::from(user_data_dir.as_str());
-        let mihomo_pipe_str = mihomo_pipe.as_str().to_owned();
+        let core_pipe = core_pipe.as_str().to_owned();
         let boot = bootstrap_yaml.as_str().to_owned();
-        match run_bootstrap(pipe, mihomo, data_core, user_data, mihomo_pipe_str, boot) {
+        if let Some(inst) = INSTANCE.get() {
+            // Hub 路径和 IPC 生命周期固定，恢复核心时刷新当前启动配置。
+            return match run_core_task(
+                inst.core.clone(),
+                CoreTask::ActivateConfig(boot),
+                Duration::from_secs(10),
+            ) {
+                Ok(()) => BootstrapResult::ok(),
+                Err(e) => BootstrapResult::err(format!("Core startup failed: {e:#}")),
+            };
+        }
+        match run_bootstrap(pipe, core, data_core, user_data, core_pipe, boot) {
             Ok(inst) => {
                 let _ = INSTANCE.set(inst);
                 BootstrapResult::ok()
@@ -166,7 +175,11 @@ pub fn hub_start_core() -> BootstrapResult {
         let Some(inst) = INSTANCE.get() else {
             return BootstrapResult::err("Hub is not initialized");
         };
-        match run_core_task(inst.core.clone(), CoreTask::Start, Duration::from_secs(10)) {
+        match run_core_task(
+            inst.core.clone(),
+            CoreTask::StartConfirmed,
+            Duration::from_secs(10),
+        ) {
             Ok(()) => BootstrapResult::ok(),
             Err(e) => BootstrapResult::err(format!("Core startup failed: {e:#}")),
         }

--- a/native/hub/src/capabilities/bootstrap.rs
+++ b/native/hub/src/capabilities/bootstrap.rs
@@ -182,7 +182,8 @@ pub fn hub_stop_core() -> BootstrapResult {
         let Some(inst) = INSTANCE.get() else {
             return BootstrapResult::err("Hub is not initialized");
         };
-        match run_core_task(inst.core.clone(), CoreTask::Stop, Duration::from_secs(7)) {
+        // 普通模式核心停止总预算固定为 5 秒。
+        match run_core_task(inst.core.clone(), CoreTask::Stop, Duration::from_secs(5)) {
             Ok(()) => BootstrapResult::ok(),
             Err(e) => BootstrapResult::err(format!("Core shutdown failed: {e:#}")),
         }

--- a/native/hub/src/infra/core_runtime.rs
+++ b/native/hub/src/infra/core_runtime.rs
@@ -26,8 +26,7 @@ pub enum CoreState {
 
 pub struct CoreRuntime {
     paths: HubPaths,
-    mihomo_pipe: String,
-    bootstrap_yaml: String,
+    core_pipe: String,
     api: CoreApiClient,
 
     state: Arc<Mutex<CoreInner>>,
@@ -39,10 +38,16 @@ struct CoreInner {
     state: CoreState,
     child: Option<ChildHandle>,
     log_task: Option<JoinHandle<()>>,
+    desired_yaml: String,
     last_active_yaml: Option<serde_yaml_ng::Value>,
     last_error: Option<String>,
     // 世代号隔离过期后台任务，防止旧启动流程回写新状态。
     generation: u64,
+}
+
+struct PendingCoreConfig {
+    desired_yaml: String,
+    active_yaml: serde_yaml_ng::Value,
 }
 
 fn broadcast_state(events: &broadcast::Sender<Outgoing>, inner: &CoreInner) {
@@ -114,20 +119,20 @@ fn replace_log_stream(
 impl CoreRuntime {
     pub fn new(
         paths: HubPaths,
-        mihomo_pipe: String,
+        core_pipe: String,
         bootstrap_yaml: String,
         events: broadcast::Sender<Outgoing>,
     ) -> Result<Self> {
-        let api = CoreApiClient::new(&mihomo_pipe);
+        let api = CoreApiClient::new(&core_pipe);
         Ok(Self {
             paths,
-            mihomo_pipe,
-            bootstrap_yaml,
+            core_pipe,
             api,
             state: Arc::new(Mutex::new(CoreInner {
                 state: CoreState::Unavailable,
                 child: None,
                 log_task: None,
+                desired_yaml: bootstrap_yaml,
                 last_active_yaml: None,
                 last_error: None,
                 generation: 0,
@@ -149,7 +154,7 @@ impl CoreRuntime {
             return Ok(());
         }
         if has_child {
-            self.stop_mihomo().await?;
+            self.stop_core_process().await?;
         }
 
         self.start_initial_locked().await
@@ -157,20 +162,30 @@ impl CoreRuntime {
 
     async fn start_initial_locked(&self) -> Result<()> {
         self.paths.ensure_dirs()?;
-        // 先写 bootstrap，让活动 YAML 差异基线匹配 mihomo 实际配置。
-        std::fs::write(&self.paths.bootstrap_yaml, &self.bootstrap_yaml)
+        let desired_yaml = {
+            let inner = self.state.lock().await;
+            inner.desired_yaml.clone()
+        };
+        // 先写 bootstrap，让活动 YAML 差异基线匹配核心实际配置。
+        std::fs::write(&self.paths.bootstrap_yaml, desired_yaml)
             .context("Failed to write bootstrap yaml")?;
-        let initial_yaml = self.rewrite_active_yaml(&self.paths.bootstrap_yaml).await?;
+        let (initial_yaml, _) = self.rewrite_active_yaml(&self.paths.bootstrap_yaml).await?;
         let log_level = read_log_level(&initial_yaml);
         {
             let mut inner = self.state.lock().await;
 
             inner.last_active_yaml = Some(initial_yaml);
         }
-        self.start_mihomo(&self.paths.active_yaml, log_level).await
+        self.start_core_process(&self.paths.active_yaml, log_level, None)
+            .await
     }
 
-    async fn start_mihomo(&self, yaml_path: &Path, log_level: String) -> Result<()> {
+    async fn start_core_process(
+        &self,
+        yaml_path: &Path,
+        log_level: String,
+        pending_config: Option<PendingCoreConfig>,
+    ) -> Result<()> {
         let generation = {
             let mut inner = self.state.lock().await;
             inner.generation += 1;
@@ -179,20 +194,17 @@ impl CoreRuntime {
             broadcast_state(&self.events, &inner);
             inner.generation
         };
-        let child = match process::spawn(
-            &self.paths.mihomo_path,
-            yaml_path,
-            &self.paths.data_core_dir,
-        ) {
-            Ok(c) => c,
-            Err(e) => {
-                let mut inner = self.state.lock().await;
-                inner.state = CoreState::Crashed;
-                inner.last_error = Some(format!("spawn failed: {e}"));
-                broadcast_state(&self.events, &inner);
-                return Err(e.context("Failed to spawn mihomo"));
-            }
-        };
+        let child =
+            match process::spawn(&self.paths.core_path, yaml_path, &self.paths.data_core_dir) {
+                Ok(c) => c,
+                Err(e) => {
+                    let mut inner = self.state.lock().await;
+                    inner.state = CoreState::Crashed;
+                    inner.last_error = Some(format!("spawn failed: {e}"));
+                    broadcast_state(&self.events, &inner);
+                    return Err(e.context("Failed to spawn core"));
+                }
+            };
         let pid = child.pid;
         // 等待器在 child 转移前创建，后续 future 不再借用句柄。
         let waiter = process::exit_waiter(&child);
@@ -248,6 +260,10 @@ impl CoreRuntime {
 
             match ready {
                 Ok(_) => {
+                    if let Some(config) = pending_config {
+                        inner.desired_yaml = config.desired_yaml;
+                        inner.last_active_yaml = Some(config.active_yaml);
+                    }
                     replace_log_stream(&mut inner, api.clone(), events.clone(), &log_level);
                     inner.state = CoreState::Running;
                     broadcast_state(&events, &inner);
@@ -260,11 +276,11 @@ impl CoreRuntime {
             }
         });
 
-        tracing::info!("mihomo started pid={pid}");
+        tracing::info!("core started pid={pid}");
         Ok(())
     }
 
-    async fn stop_mihomo(&self) -> Result<()> {
+    async fn stop_core_process(&self) -> Result<()> {
         let (child_opt, log_task) = {
             let mut inner = self.state.lock().await;
             // 主动停止推进世代，旧退出监视器不会把它记成崩溃。
@@ -281,7 +297,7 @@ impl CoreRuntime {
         if let Some(child) = child_opt {
             process::shutdown(child, Duration::from_secs(5))
                 .await
-                .context("Failed to shut down mihomo")?;
+                .context("Failed to shut down core")?;
         }
         let mut inner = self.state.lock().await;
         inner.state = CoreState::Stopped;
@@ -291,7 +307,7 @@ impl CoreRuntime {
 
     pub async fn stop_core(&self) -> Result<()> {
         let _lifecycle = self.lifecycle.lock().await;
-        self.stop_mihomo().await
+        self.stop_core_process().await
     }
 
     pub async fn start_core(&self) -> Result<()> {
@@ -299,7 +315,32 @@ impl CoreRuntime {
         self.start_if_needed_locked().await
     }
 
-    async fn rewrite_active_yaml(&self, source_path: &Path) -> Result<serde_yaml_ng::Value> {
+    pub async fn start_core_with_config(&self, desired_yaml: String) -> Result<()> {
+        let _lifecycle = self.lifecycle.lock().await;
+        let has_child = self.state.lock().await.child.is_some();
+        if has_child {
+            self.stop_core_process().await?;
+        }
+        self.paths.ensure_dirs()?;
+        std::fs::write(&self.paths.bootstrap_yaml, &desired_yaml)
+            .context("Failed to write bootstrap yaml")?;
+        let (active_yaml, _) = self.rewrite_active_yaml(&self.paths.bootstrap_yaml).await?;
+        let log_level = read_log_level(&active_yaml);
+        self.start_core_process(
+            &self.paths.active_yaml,
+            log_level,
+            Some(PendingCoreConfig {
+                desired_yaml,
+                active_yaml,
+            }),
+        )
+        .await
+    }
+
+    async fn rewrite_active_yaml(
+        &self,
+        source_path: &Path,
+    ) -> Result<(serde_yaml_ng::Value, String)> {
         let text = std::fs::read_to_string(source_path)
             .with_context(|| format!("Failed to read runtime yaml: {}", source_path.display()))?;
         let mut yaml: serde_yaml_ng::Value =
@@ -312,14 +353,14 @@ impl CoreRuntime {
             let (insert_key, remove_key) = ("external-controller-pipe", "external-controller-unix");
             map.insert(
                 serde_yaml_ng::Value::String(insert_key.into()),
-                serde_yaml_ng::Value::String(self.mihomo_pipe.clone()),
+                serde_yaml_ng::Value::String(self.core_pipe.clone()),
             );
             map.remove(serde_yaml_ng::Value::String(remove_key.into()));
         }
         let serialized = serde_yaml_ng::to_string(&yaml).context("Failed to serialize yaml")?;
-        std::fs::write(&self.paths.active_yaml, serialized)
+        std::fs::write(&self.paths.active_yaml, &serialized)
             .context("Failed to write _active.yaml")?;
-        Ok(yaml)
+        Ok((yaml, serialized))
     }
 
     pub async fn apply_config(
@@ -338,7 +379,7 @@ impl CoreRuntime {
             }
         }
 
-        let new_yaml = match self.rewrite_active_yaml(&runtime_yaml_path).await {
+        let (new_yaml, desired_yaml) = match self.rewrite_active_yaml(&runtime_yaml_path).await {
             Ok(v) => v,
             Err(e) => {
                 return Err(ErrorBody {
@@ -382,6 +423,7 @@ impl CoreRuntime {
                 Ok(()) => {
                     let _ = self.api.close_all_connections().await;
                     let mut inner = self.state.lock().await;
+                    inner.desired_yaml = desired_yaml;
                     inner.last_active_yaml = Some(new_yaml);
                     let pid = current_pid(&inner)?;
                     return Ok(serde_json::json!({ "mode": "reload", "pid": pid }));
@@ -406,20 +448,29 @@ impl CoreRuntime {
             }
         }
 
-        if let Err(e) = self.stop_mihomo().await {
+        if let Err(e) = self.stop_core_process().await {
             return Err(ErrorBody {
                 code: "hub.internal".into(),
                 message: format!("{e:#}"),
             });
         }
-        if let Err(e) = self.start_mihomo(&self.paths.active_yaml, log_level).await {
+        if let Err(e) = self
+            .start_core_process(
+                &self.paths.active_yaml,
+                log_level,
+                Some(PendingCoreConfig {
+                    desired_yaml,
+                    active_yaml: new_yaml,
+                }),
+            )
+            .await
+        {
             return Err(ErrorBody {
                 code: "core.spawn_failed".into(),
                 message: format!("{e:#}"),
             });
         }
-        let mut inner = self.state.lock().await;
-        inner.last_active_yaml = Some(new_yaml);
+        let inner = self.state.lock().await;
         let pid = current_pid(&inner)?;
         Ok(serde_json::json!({ "mode": "restart", "pid": pid }))
     }
@@ -429,8 +480,7 @@ impl CoreRuntime {
         serde_json::json!({
             "state": inner.state,
             "pid": inner.child.as_ref().map(|c| c.pid),
-            "external_controller": self.mihomo_pipe,
-            "mihomo_pipe": self.mihomo_pipe,
+            "external_controller": self.core_pipe,
             "last_error": inner.last_error,
         })
     }
@@ -456,7 +506,7 @@ impl MethodHandler for CoreRuntime {
             }
             "core.stop" => {
                 let _lifecycle = self.lifecycle.lock().await;
-                self.stop_mihomo().await.map_err(|e| ErrorBody {
+                self.stop_core_process().await.map_err(|e| ErrorBody {
                     code: "hub.internal".into(),
                     message: format!("{e:#}"),
                 })?;
@@ -464,7 +514,7 @@ impl MethodHandler for CoreRuntime {
             }
             "core.restart" => {
                 let _lifecycle = self.lifecycle.lock().await;
-                self.stop_mihomo().await.map_err(|e| ErrorBody {
+                self.stop_core_process().await.map_err(|e| ErrorBody {
                     code: "hub.internal".into(),
                     message: format!("{e:#}"),
                 })?;

--- a/native/hub/src/infra/paths.rs
+++ b/native/hub/src/infra/paths.rs
@@ -5,12 +5,12 @@ pub struct HubPaths {
     pub runtime_dir: PathBuf,
     pub bootstrap_yaml: PathBuf,
     pub active_yaml: PathBuf,
-    pub mihomo_path: PathBuf,
+    pub core_path: PathBuf,
     pub data_core_dir: PathBuf,
 }
 
 impl HubPaths {
-    pub fn new(user_data_dir: PathBuf, mihomo_path: PathBuf, data_core_dir: PathBuf) -> Self {
+    pub fn new(user_data_dir: PathBuf, core_path: PathBuf, data_core_dir: PathBuf) -> Self {
         let runtime_dir = user_data_dir.join("runtime");
 
         let bootstrap_yaml = data_core_dir.join("_bootstrap.yaml");
@@ -19,7 +19,7 @@ impl HubPaths {
             runtime_dir,
             bootstrap_yaml,
             active_yaml,
-            mihomo_path,
+            core_path,
             data_core_dir,
         }
     }

--- a/native/hub/src/infra/process.rs
+++ b/native/hub/src/infra/process.rs
@@ -122,7 +122,7 @@ mod windows_impl {
 
     pub fn spawn(binary: &Path, yaml_path: &Path, data_core_dir: &Path) -> Result<ChildHandle> {
         // 先挂起进程并加入 Job，再恢复运行。
-        // 任一步失败都能清理句柄，避免留下孤儿 mihomo。
+        // 任一步失败都能清理句柄，避免留下孤儿核心进程。
         let binary_str = binary.to_string_lossy();
         let yaml_str = yaml_path.to_string_lossy();
         let data_str = data_core_dir.to_string_lossy();
@@ -279,29 +279,29 @@ mod windows_impl {
                 let mut failure = None;
                 if let Some(j) = job {
                     if let Err(error) = CloseHandle(isize_to_handle(j)) {
-                        failure = Some(anyhow!("Failed to close mihomo Job Object: {error}"));
+                        failure = Some(anyhow!("Failed to close core Job Object: {error}"));
                     }
                 }
                 if let Some(p) = proc {
                     let wait = WaitForSingleObject(isize_to_handle(p), timeout.as_millis() as u32);
                     if wait == WAIT_TIMEOUT {
                         failure
-                            .get_or_insert_with(|| anyhow!("Timed out waiting for mihomo to exit"));
+                            .get_or_insert_with(|| anyhow!("Timed out waiting for core to exit"));
                     } else if wait == WAIT_FAILED {
                         failure.get_or_insert_with(|| {
                             anyhow!(
-                                "Failed to wait for mihomo to exit: {}",
+                                "Failed to wait for core to exit: {}",
                                 windows::core::Error::from_thread()
                             )
                         });
                     } else if wait != WAIT_OBJECT_0 {
                         failure.get_or_insert_with(|| {
-                            anyhow!("Unexpected mihomo wait result: {}", wait.0)
+                            anyhow!("Unexpected core wait result: {}", wait.0)
                         });
                     }
                     if let Err(error) = CloseHandle(isize_to_handle(p)) {
                         failure.get_or_insert_with(|| {
-                            anyhow!("Failed to close mihomo process handle: {error}")
+                            anyhow!("Failed to close core process handle: {error}")
                         });
                     }
                 }
@@ -347,10 +347,10 @@ mod unix_impl {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .context("Failed to start mihomo")?;
+            .context("Failed to start core")?;
         let pid = child
             .id()
-            .ok_or_else(|| anyhow!("Unable to get mihomo PID"))?;
+            .ok_or_else(|| anyhow!("Unable to get core PID"))?;
         let kill = Arc::new(Notify::new());
         let (exited_tx, exited_rx) = watch::channel(None);
         let kill_listener = kill.clone();
@@ -370,7 +370,7 @@ mod unix_impl {
                 },
                 Err(error) => UnixExit {
                     code: u32::MAX,
-                    error: Some(format!("Failed to wait for mihomo: {error}")),
+                    error: Some(format!("Failed to wait for core: {error}")),
                 },
             };
             let _ = exited_tx.send(Some(outcome));
@@ -401,10 +401,10 @@ mod unix_impl {
         let mut exited = child.inner.exited;
         let outcome = tokio::time::timeout(timeout, exited.wait_for(Option::is_some))
             .await
-            .map_err(|_| anyhow!("Timed out waiting for mihomo to exit"))?
-            .map_err(|_| anyhow!("Mihomo exit monitor stopped unexpectedly"))?
+            .map_err(|_| anyhow!("Timed out waiting for core to exit"))?
+            .map_err(|_| anyhow!("Core exit monitor stopped unexpectedly"))?
             .clone()
-            .ok_or_else(|| anyhow!("Mihomo exit monitor returned no result"))?;
+            .ok_or_else(|| anyhow!("Core exit monitor returned no result"))?;
         if let Some(error) = outcome.error {
             return Err(anyhow!(error));
         }

--- a/native/service/Cargo.toml
+++ b/native/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stelliberty_service"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 publish = false
 

--- a/native/service/src/core.rs
+++ b/native/service/src/core.rs
@@ -11,6 +11,8 @@ use crate::channel::core_lock_prefix;
 use crate::logging;
 
 const CORE_LOCK_SUFFIX: &str = ".lock";
+// 核心停止固定 5 秒；服务退出时锁等待也计入该预算。
+const CORE_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -76,7 +78,8 @@ impl CoreManager {
 
     async fn start_locked(&self, request: StartCoreRequest) -> Result<u32> {
         validate_start_request(&request)?;
-        self.stop_with_restore_flag_locked(false).await?;
+        self.stop_with_restore_flag_locked(false, CORE_STOP_TIMEOUT)
+            .await?;
         let killed = self.cleanup_orphan_cores_checked().await?;
         log_cleaned_orphan_cores(&killed);
         let child = spawn_child(
@@ -141,10 +144,24 @@ impl CoreManager {
 
     pub async fn stop(&self) -> Result<()> {
         let _guard = self.lifecycle.lock().await;
-        self.stop_with_restore_flag_locked(false).await
+        self.stop_with_restore_flag_locked(false, CORE_STOP_TIMEOUT)
+            .await
     }
 
-    async fn stop_with_restore_flag_locked(&self, restore_after_heartbeat: bool) -> Result<()> {
+    pub async fn stop_for_service_shutdown(&self) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + CORE_STOP_TIMEOUT;
+        let _guard = tokio::time::timeout_at(deadline, self.lifecycle.lock())
+            .await
+            .map_err(|_| anyhow!("Core stop timed out waiting for another lifecycle operation"))?;
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        self.stop_with_restore_flag_locked(false, remaining).await
+    }
+
+    async fn stop_with_restore_flag_locked(
+        &self,
+        restore_after_heartbeat: bool,
+        timeout: Duration,
+    ) -> Result<()> {
         let (child, task, generation) = {
             let mut inner = self.inner.lock().await;
             inner.generation += 1;
@@ -160,7 +177,7 @@ impl CoreManager {
         }
 
         if let Some(child) = child {
-            shutdown_child(child, Duration::from_secs(5)).await?;
+            shutdown_child(child, timeout).await?;
             logging::info("Core stopped by service");
         }
 
@@ -176,7 +193,10 @@ impl CoreManager {
     pub async fn stop_for_heartbeat_timeout(&self) {
         let _guard = self.lifecycle.lock().await;
         let had_child = self.status().await.pid.is_some();
-        if let Err(error) = self.stop_with_restore_flag_locked(had_child).await {
+        if let Err(error) = self
+            .stop_with_restore_flag_locked(had_child, CORE_STOP_TIMEOUT)
+            .await
+        {
             logging::warn(format!(
                 "Failed to stop core after heartbeat timeout: {error:#}"
             ));

--- a/native/service/src/ipc.rs
+++ b/native/service/src/ipc.rs
@@ -99,10 +99,24 @@ impl ServiceState {
     }
 
     pub async fn stop_core(&self) {
-        if let Err(error) = self.core.stop().await {
-            logging::warn(format!(
-                "Failed to stop core during service shutdown: {error:#}"
-            ));
+        let status = self.core.status().await;
+        let started_at = Instant::now();
+        logging::info(format!(
+            "Service core shutdown started: state={} pid={}",
+            core_state_text(status.state),
+            status
+                .pid
+                .map_or_else(|| "none".to_string(), |pid| pid.to_string())
+        ));
+        match self.core.stop_for_service_shutdown().await {
+            Ok(()) => logging::info(format!(
+                "Service core shutdown completed: elapsed={}ms",
+                started_at.elapsed().as_millis()
+            )),
+            Err(error) => logging::warn(format!(
+                "Service core shutdown failed: elapsed={}ms error={error:#}",
+                started_at.elapsed().as_millis()
+            )),
         }
     }
     async fn status(&self) -> ServiceResponse {

--- a/native/service/src/service.rs
+++ b/native/service/src/service.rs
@@ -77,12 +77,15 @@ fn run_windows_service() -> Result<()> {
 
     const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
-    let (control_tx, control_rx) = mpsc::channel::<()>();
+    let (control_tx, control_rx) = mpsc::channel::<&'static str>();
     let event_handler = move |control_event| -> ServiceControlHandlerResult {
         match control_event {
             ServiceControl::Stop => {
-                logging::info("Windows service stop control received");
-                let _ = control_tx.send(());
+                let _ = control_tx.send("stop");
+                ServiceControlHandlerResult::NoError
+            }
+            ServiceControl::Shutdown => {
+                let _ = control_tx.send("os-shutdown");
                 ServiceControlHandlerResult::NoError
             }
             ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
@@ -127,7 +130,7 @@ fn run_windows_service() -> Result<()> {
             .set_service_status(ServiceStatus {
                 service_type: SERVICE_TYPE,
                 current_state: WinServiceState::Running,
-                controls_accepted: ServiceControlAccept::STOP,
+                controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
                 exit_code: ServiceExitCode::Win32(0),
                 checkpoint: 0,
                 wait_hint: Duration::default(),
@@ -135,17 +138,45 @@ fn run_windows_service() -> Result<()> {
             })
             .context("Failed to set the service running status")?;
 
-        tokio::select! {
+        let (shutdown_source, service_result) = tokio::select! {
             result = server => {
-                result.context("Service IPC task failed")??;
+                let result = result
+                    .context("Service IPC task failed")
+                    .and_then(|server_result| server_result);
+                ("ipc", result)
             }
-            _ = control => {
-                logging::info("Windows service control task ended");
+            result = control => {
+                let source = result.map_or("control-task-failed", |control_result| {
+                    control_result.unwrap_or("control-channel-closed")
+                });
+                (source, Ok(()))
             }
-        }
+        };
+        logging::info(format!(
+            "Windows service shutdown started (origin: {shutdown_source})"
+        ));
+        // 核心退出最多等待 5 秒，向 SCM 申报 8 秒停止预算。
+        let stop_pending_result = status_handle
+            .set_service_status(ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: WinServiceState::StopPending,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 1,
+                wait_hint: Duration::from_secs(8),
+                process_id: None,
+            })
+            .context("Failed to set the service stop-pending status");
         heartbeat.abort();
         state.stop_core().await;
-        logging::info("Windows service stopped");
+        logging::info(format!(
+            "Windows service shutdown completed (origin: {shutdown_source})"
+        ));
+        if let Err(error) = stop_pending_result {
+            logging::warn(format!(
+                "Failed to report Windows service stop-pending status: {error:#}"
+            ));
+        }
 
         status_handle
             .set_service_status(ServiceStatus {
@@ -159,6 +190,6 @@ fn run_windows_service() -> Result<()> {
             })
             .context("Failed to set the service stopped status")?;
 
-        Ok::<(), anyhow::Error>(())
+        service_result
     })
 }

--- a/src/Stelliberty.Application/Platform/ServiceModeCoreHostRequest.cs
+++ b/src/Stelliberty.Application/Platform/ServiceModeCoreHostRequest.cs
@@ -1,6 +1,6 @@
 namespace Stelliberty.Application.Platform;
 
 public sealed record ServiceModeCoreHostRequest(
-    string MihomoPath,
+    string CorePath,
     string DataCoreDir,
     string ConfigPath);

--- a/src/Stelliberty.Application/Proxies/ProxySelectionRestorer.cs
+++ b/src/Stelliberty.Application/Proxies/ProxySelectionRestorer.cs
@@ -1,13 +1,16 @@
 using Stelliberty.Application.Diagnostics;
+using Stelliberty.Application.Subscriptions;
 using Stelliberty.Domain.Proxies;
 
 namespace Stelliberty.Application.Proxies;
 
 public sealed class ProxySelectionRestorer(
     IProxyCoreClient coreClient,
-    IProxyConfigProvider configProvider,
+    IProxyConfigProvider coreConfigProvider,
+    IProxyConfigProvider selectedRuntimeConfigProvider,
     StoredProxySelectionConfigProvider selectionProvider,
-    ProxySelectionSyncState syncState)
+    ProxySelectionSyncState syncState,
+    ISubscriptionSelectionStore subscriptionSelectionStore)
 {
     private static readonly TimeSpan LoadRetryDelay = TimeSpan.FromMilliseconds(250);
     private const int LoadMaxAttempts = 20;
@@ -15,17 +18,60 @@ public sealed class ProxySelectionRestorer(
 
     public async Task RestoreCurrentSubscriptionAsync(CancellationToken cancellationToken = default)
     {
+        var subscriptionId = SuspendCoreSelectionImport("startup");
+        await RestoreSubscriptionAsync(subscriptionId, "startup", cancellationToken);
+    }
+
+    public string? SuspendCoreSelectionImport(string origin)
+    {
         syncState.DisableCoreSelectionImport();
+        var subscriptionId = subscriptionSelectionStore.GetCurrentSubscriptionId();
+        AppLogger.Info($"Proxy selection import suspended: origin={origin} subscription={subscriptionId ?? "none"}");
+        return subscriptionId;
+    }
+
+    public async Task RestoreSubscriptionAsync(
+        string? subscriptionId,
+        string origin,
+        CancellationToken cancellationToken = default)
+    {
+        syncState.DisableCoreSelectionImport();
+        if (string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            AppLogger.Info($"Proxy selection restore skipped: origin={origin} reason=no-subscription");
+            return;
+        }
+
+        if (!IsCurrentSubscription(subscriptionId))
+        {
+            AppLogger.Info($"Proxy selection restore skipped: origin={origin} subscription={subscriptionId} reason=selection-changed");
+            return;
+        }
+
+        AppLogger.Info($"Proxy selection restore started: origin={origin} subscription={subscriptionId}");
         var canImportCoreSelections = false;
         try
         {
-            var config = await LoadRuntimeConfigAsync(cancellationToken);
-            config = selectionProvider.ApplyStoredSelections(config);
+            var expectedConfig = await selectedRuntimeConfigProvider.LoadAsync(cancellationToken);
+            var config = await LoadRuntimeConfigAsync(expectedConfig, cancellationToken);
+            if (!IsCurrentSubscription(subscriptionId))
+            {
+                AppLogger.Info($"Proxy selection restore skipped: origin={origin} subscription={subscriptionId} reason=selection-changed");
+                return;
+            }
+
+            config = selectionProvider.ApplyStoredSelections(config, subscriptionId);
             var restoredCount = 0;
             var clearedCount = 0;
             var failedCount = 0;
             foreach (var group in config.Groups)
             {
+                if (!IsCurrentSubscription(subscriptionId))
+                {
+                    AppLogger.Info($"Proxy selection restore interrupted: origin={origin} subscription={subscriptionId} reason=selection-changed");
+                    return;
+                }
+
                 var selection = group.UserSelectionName;
                 if (!group.IsManualSelectable)
                 {
@@ -67,18 +113,25 @@ public sealed class ProxySelectionRestorer(
                 }
             }
 
-            AppLogger.Info($"Proxy selection restore completed: restored={restoredCount} cleared={clearedCount} failed={failedCount}");
+            AppLogger.Info($"Proxy selection restore completed: origin={origin} subscription={subscriptionId} restored={restoredCount} cleared={clearedCount} failed={failedCount}");
             canImportCoreSelections = failedCount == 0;
             if (!canImportCoreSelections)
             {
                 throw new InvalidOperationException($"Proxy selection restore incomplete: failed={failedCount}");
             }
 
-            selectionProvider.PruneInvalidStoredSelections(config);
+            if (!IsCurrentSubscription(subscriptionId))
+            {
+                canImportCoreSelections = false;
+                AppLogger.Info($"Proxy selection restore invalidated: origin={origin} subscription={subscriptionId} reason=selection-changed");
+                return;
+            }
+
+            selectionProvider.PruneInvalidStoredSelections(config, subscriptionId);
         }
         finally
         {
-            if (canImportCoreSelections)
+            if (canImportCoreSelections && IsCurrentSubscription(subscriptionId))
             {
                 syncState.EnableCoreSelectionImport();
             }
@@ -90,15 +143,30 @@ public sealed class ProxySelectionRestorer(
         }
     }
 
-    private async Task<ProxyConfig> LoadRuntimeConfigAsync(CancellationToken cancellationToken)
+    private bool IsCurrentSubscription(string subscriptionId)
+    {
+        return string.Equals(
+            subscriptionSelectionStore.GetCurrentSubscriptionId(),
+            subscriptionId,
+            StringComparison.Ordinal);
+    }
+
+    private async Task<ProxyConfig> LoadRuntimeConfigAsync(
+        ProxyConfig expectedConfig,
+        CancellationToken cancellationToken)
     {
         ProxyConfig? previous = null;
+        ProxyConfig? latest = null;
         var stableCount = 0;
+        // 目标配置连续稳定后再恢复，避免核心切换期间命中过渡快照。
         for (var attempt = 1; attempt <= LoadMaxAttempts; attempt++)
         {
-            var config = await configProvider.LoadAsync(cancellationToken);
+            var config = await coreConfigProvider.LoadAsync(cancellationToken);
+            latest = config;
 
-            if (IsReady(config) && IsSameGroupSnapshot(previous, config))
+            if (IsReady(config)
+                && MatchesExpectedConfig(expectedConfig, config)
+                && IsSameGroupSnapshot(previous, config))
             {
                 stableCount++;
                 if (stableCount >= StableSnapshotCount)
@@ -121,7 +189,8 @@ public sealed class ProxySelectionRestorer(
             await Task.Delay(LoadRetryDelay, cancellationToken);
         }
 
-        throw new InvalidOperationException("Core proxy groups did not become stable");
+        throw new InvalidOperationException(
+            $"Core proxy groups did not match the selected runtime config: expected={FormatGroupNames(expectedConfig)} actual={FormatGroupNames(latest)}");
     }
 
     private static bool IsSameGroupSnapshot(ProxyConfig? previous, ProxyConfig current)
@@ -153,5 +222,53 @@ public sealed class ProxySelectionRestorer(
         return config.Groups
             .Where(group => group.IsManualSelectable)
             .All(group => group.All.Count > 0 && group.All.All(entryNames.Contains));
+    }
+
+    private static bool MatchesExpectedConfig(ProxyConfig expected, ProxyConfig actual)
+    {
+        var expectedGroups = expected.Groups
+            .Where(group => !IsGlobalGroup(group))
+            .ToDictionary(group => group.Name, StringComparer.Ordinal);
+        var actualGroups = actual.Groups
+            .Where(group => !IsGlobalGroup(group))
+            .ToDictionary(group => group.Name, StringComparer.Ordinal);
+        if (expectedGroups.Count != actualGroups.Count
+            || !expected.Nodes.Keys.All(actual.Nodes.ContainsKey))
+        {
+            return false;
+        }
+
+        foreach (var (name, expectedGroup) in expectedGroups)
+        {
+            if (!actualGroups.TryGetValue(name, out var actualGroup)
+                || !string.Equals(
+                    NormalizeGroupType(expectedGroup.Type),
+                    NormalizeGroupType(actualGroup.Type),
+                    StringComparison.Ordinal)
+                || !expectedGroup.All.All(actualGroup.All.Contains))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsGlobalGroup(ProxyGroup group)
+    {
+        return string.Equals(group.Name, "GLOBAL", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeGroupType(string type)
+    {
+        var normalized = type.Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+        return normalized == "selector" ? "select" : normalized;
+    }
+
+    private static string FormatGroupNames(ProxyConfig? config)
+    {
+        return config is null
+            ? "unavailable"
+            : string.Join(',', config.Groups.Where(group => !IsGlobalGroup(group)).Select(group => group.Name));
     }
 }

--- a/src/Stelliberty.Application/Proxies/ProxySelectionRestoringCoreManager.cs
+++ b/src/Stelliberty.Application/Proxies/ProxySelectionRestoringCoreManager.cs
@@ -1,0 +1,260 @@
+using Stelliberty.Application.CoreLogs;
+using Stelliberty.Application.Diagnostics;
+using Stelliberty.Application.Runtime;
+using Stelliberty.Domain.CoreLogs;
+
+namespace Stelliberty.Application.Proxies;
+
+public sealed class ProxySelectionRestoringCoreManager : ICoreManager, IDisposable
+{
+    private readonly ICoreManager _inner;
+    private readonly ProxySelectionRestorer _restorer;
+    private readonly SemaphoreSlim _resetGate = new(1, 1);
+    private readonly object _stateGate = new();
+    private bool _hasObservedRunning;
+    private bool _isManagedReset;
+    private bool _hasPendingObservedReset;
+    private string? _pendingObservedSubscriptionId;
+    private int? _lastRunningPid;
+    private bool _isDisposed;
+
+    public ProxySelectionRestoringCoreManager(ICoreManager inner, ProxySelectionRestorer restorer)
+    {
+        _inner = inner;
+        _restorer = restorer;
+        _inner.StateChanged += OnInnerStateChanged;
+        _inner.CoreLogReceived += OnInnerCoreLogReceived;
+    }
+
+    public event EventHandler<CoreSnapshot>? StateChanged;
+
+    public event EventHandler<CoreLogMessage>? CoreLogReceived;
+
+    public Task<CoreSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        return _inner.GetSnapshotAsync(cancellationToken);
+    }
+
+    public Task<CoreApplyConfigResult> ApplyConfigAsync(
+        CoreApplyConfigRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        return RunCoreResetAsync(
+            "runtime-config-apply",
+            request.SubscriptionId,
+            token => _inner.ApplyConfigAsync(request, token),
+            cancellationToken);
+    }
+
+    public Task RestartAsync(CancellationToken cancellationToken = default)
+    {
+        return RunCoreResetAsync(
+            "core-restart",
+            token => _inner.RestartAsync(token),
+            cancellationToken);
+    }
+
+    public Task<T> RunCoreResetAsync<T>(
+        string origin,
+        Func<CancellationToken, Task<T>> operation,
+        CancellationToken cancellationToken = default)
+    {
+        return RunCoreResetAsync(origin, expectedSubscriptionId: null, operation, cancellationToken);
+    }
+
+    public void NotifyCoreResetStarting(string origin)
+    {
+        _restorer.SuspendCoreSelectionImport(origin);
+    }
+
+    public async Task RestoreCurrentCoreSelectionsAsync(
+        string origin,
+        CancellationToken cancellationToken = default)
+    {
+        await _resetGate.WaitAsync(cancellationToken);
+        try
+        {
+            var subscriptionId = _restorer.SuspendCoreSelectionImport(origin);
+            await TryRestoreIfRunningAsync(subscriptionId, origin);
+        }
+        finally
+        {
+            _resetGate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+        _inner.StateChanged -= OnInnerStateChanged;
+        _inner.CoreLogReceived -= OnInnerCoreLogReceived;
+    }
+
+    private async Task RunCoreResetAsync(
+        string origin,
+        Func<CancellationToken, Task> operation,
+        CancellationToken cancellationToken)
+    {
+        await RunCoreResetAsync(
+            origin,
+            expectedSubscriptionId: null,
+            async token =>
+            {
+                await operation(token);
+                return true;
+            },
+            cancellationToken);
+    }
+
+    private async Task<T> RunCoreResetAsync<T>(
+        string origin,
+        string? expectedSubscriptionId,
+        Func<CancellationToken, Task<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        await _resetGate.WaitAsync(cancellationToken);
+        var subscriptionId = _restorer.SuspendCoreSelectionImport(origin);
+        if (expectedSubscriptionId is not null)
+        {
+            subscriptionId = string.IsNullOrWhiteSpace(expectedSubscriptionId) ? null : expectedSubscriptionId;
+        }
+
+        SetManagedReset(true);
+        try
+        {
+            var result = await operation(cancellationToken);
+            await TryRestoreIfRunningAsync(subscriptionId, origin);
+            return result;
+        }
+        finally
+        {
+            SetManagedReset(false);
+            _resetGate.Release();
+        }
+    }
+
+    private async Task TryRestoreIfRunningAsync(string? subscriptionId, string origin)
+    {
+        CoreSnapshot snapshot;
+        try
+        {
+            snapshot = await _inner.GetSnapshotAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            AppLogger.Warning($"Proxy selection restore deferred: origin={origin} reason=core-status-unavailable message={exception.Message}");
+            return;
+        }
+
+        if (snapshot.State != CoreState.Running)
+        {
+            AppLogger.Info($"Proxy selection restore deferred: origin={origin} coreState={snapshot.State}");
+            return;
+        }
+
+        try
+        {
+            await _restorer.RestoreSubscriptionAsync(subscriptionId, origin, CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            AppLogger.Warning($"Proxy selection restore failed: origin={origin} message={exception.Message}");
+        }
+    }
+
+    private void OnInnerStateChanged(object? sender, CoreSnapshot snapshot)
+    {
+        string? subscriptionId = null;
+        var shouldRestore = false;
+        lock (_stateGate)
+        {
+            if (!_isManagedReset)
+            {
+                if (snapshot.State != CoreState.Running && _hasObservedRunning)
+                {
+                    if (!_hasPendingObservedReset)
+                    {
+                        _pendingObservedSubscriptionId = _restorer.SuspendCoreSelectionImport("core-state-change");
+                        _hasPendingObservedReset = true;
+                    }
+                }
+                else if (snapshot.State == CoreState.Running)
+                {
+                    var processChanged = _hasObservedRunning
+                        && snapshot.Pid is not null
+                        && snapshot.Pid != _lastRunningPid;
+                    if (processChanged && !_hasPendingObservedReset)
+                    {
+                        _pendingObservedSubscriptionId = _restorer.SuspendCoreSelectionImport("core-process-change");
+                        _hasPendingObservedReset = true;
+                    }
+
+                    if (_hasPendingObservedReset)
+                    {
+                        subscriptionId = _pendingObservedSubscriptionId;
+                        shouldRestore = true;
+                    }
+                }
+            }
+
+            if (snapshot.State == CoreState.Running)
+            {
+                _hasObservedRunning = true;
+                _lastRunningPid = snapshot.Pid;
+            }
+        }
+
+        StateChanged?.Invoke(this, snapshot);
+        if (shouldRestore)
+        {
+            _ = RestoreObservedCoreAsync(subscriptionId);
+        }
+    }
+
+    private async Task RestoreObservedCoreAsync(string? subscriptionId)
+    {
+        await _resetGate.WaitAsync();
+        try
+        {
+            lock (_stateGate)
+            {
+                if (!_hasPendingObservedReset || _isManagedReset)
+                {
+                    return;
+                }
+
+                _hasPendingObservedReset = false;
+                _pendingObservedSubscriptionId = null;
+            }
+
+            await TryRestoreIfRunningAsync(subscriptionId, "core-state-recovery");
+        }
+        finally
+        {
+            _resetGate.Release();
+        }
+    }
+
+    private void OnInnerCoreLogReceived(object? sender, CoreLogMessage message)
+    {
+        CoreLogReceived?.Invoke(this, message);
+    }
+
+    private void SetManagedReset(bool isManagedReset)
+    {
+        lock (_stateGate)
+        {
+            _isManagedReset = isManagedReset;
+            if (isManagedReset)
+            {
+                _hasPendingObservedReset = false;
+                _pendingObservedSubscriptionId = null;
+            }
+        }
+    }
+}

--- a/src/Stelliberty.Application/Proxies/StoredProxySelectionConfigProvider.cs
+++ b/src/Stelliberty.Application/Proxies/StoredProxySelectionConfigProvider.cs
@@ -44,6 +44,11 @@ public sealed class StoredProxySelectionConfigProvider(
             return config;
         }
 
+        return ApplyStoredSelections(config, subscriptionId);
+    }
+
+    public ProxyConfig ApplyStoredSelections(ProxyConfig config, string subscriptionId)
+    {
         return ApplyStoredSelections(
             config,
             selectionStore.GetSelections(subscriptionId));
@@ -53,6 +58,16 @@ public sealed class StoredProxySelectionConfigProvider(
     {
         var subscriptionId = subscriptionSelectionStore.GetCurrentSubscriptionId();
         if (string.IsNullOrWhiteSpace(subscriptionId) || config.Groups.Count == 0)
+        {
+            return;
+        }
+
+        PruneInvalidStoredSelections(config, subscriptionId);
+    }
+
+    public void PruneInvalidStoredSelections(ProxyConfig config, string subscriptionId)
+    {
+        if (config.Groups.Count == 0)
         {
             return;
         }

--- a/src/Stelliberty.Application/Runtime/StartupBootstrapConfigBuilder.cs
+++ b/src/Stelliberty.Application/Runtime/StartupBootstrapConfigBuilder.cs
@@ -17,13 +17,13 @@ mixed-port: {MixedPort}
 allow-lan: false
 mode: rule
 log-level: {LogLevel}
-{ControllerKey}: {MihomoPipe}
+{ControllerKey}: {CorePipe}
 proxies: []
 proxy-groups: []
 rules: []
 """;
 
-    public string Build(string mihomoPipe, bool isTunRuntimeAvailable = true)
+    public string Build(string corePipe, bool isTunRuntimeAvailable = true)
     {
         try
         {
@@ -36,7 +36,7 @@ rules: []
             if (string.IsNullOrWhiteSpace(selectedSubscriptionId))
             {
                 AppLogger.Info("No subscription selected; starting the core with an empty config");
-                return BuildEmptyYaml(runtimeParams.MixedPort, runtimeParams.ClashCoreLogLevel, mihomoPipe);
+                return BuildEmptyYaml(runtimeParams.MixedPort, runtimeParams.ClashCoreLogLevel, corePipe);
             }
 
             try
@@ -51,29 +51,29 @@ rules: []
                 selectionStore.SetCurrentSubscriptionId(null);
                 failureRecorder.MarkFailed(selectedSubscriptionId, exception.Message);
                 AppLogger.Warning($"Startup config generation failed; using an empty config: {exception.Message}");
-                return BuildEmptyYaml(runtimeParams.MixedPort, runtimeParams.ClashCoreLogLevel, mihomoPipe);
+                return BuildEmptyYaml(runtimeParams.MixedPort, runtimeParams.ClashCoreLogLevel, corePipe);
             }
         }
         catch (Exception exception)
         {
             AppLogger.Warning($"Startup config generation failed; using an empty config: {exception.Message}");
-            return BuildDefaultEmptyYaml(mihomoPipe);
+            return BuildDefaultEmptyYaml(corePipe);
         }
     }
 
     // 宿主在设置存储或构造不可用时复用这个降级配置。
-    public static string BuildDefaultEmptyYaml(string mihomoPipe)
+    public static string BuildDefaultEmptyYaml(string corePipe)
     {
-        return BuildEmptyYaml(AppSettings.DefaultMixedPort, "info", mihomoPipe);
+        return BuildEmptyYaml(AppSettings.DefaultMixedPort, "info", corePipe);
     }
 
-    private static string BuildEmptyYaml(int mixedPort, string logLevel, string mihomoPipe)
+    private static string BuildEmptyYaml(int mixedPort, string logLevel, string corePipe)
     {
         return EmptyBootstrapYamlTemplate
             .Replace("{MixedPort}", mixedPort.ToString(), StringComparison.Ordinal)
             .Replace("{LogLevel}", logLevel, StringComparison.Ordinal)
             .Replace("{ControllerKey}", ControllerKey(), StringComparison.Ordinal)
-            .Replace("{MihomoPipe}", mihomoPipe, StringComparison.Ordinal);
+            .Replace("{CorePipe}", corePipe, StringComparison.Ordinal);
     }
 
     private static string ControllerKey()

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -49,7 +49,10 @@ public sealed partial class App : Avalonia.Application
     private DispatcherTimer? _subscriptionAutoUpdateTimer;
     private DispatcherTimer? _homeRuntimeTimer;
     private DispatcherTimer? _webDavBackupTimer;
+    private int _isOsShutdownRequested;
     private bool _isServiceModeCoreHostActive;
+    // 主动退出最多等待服务核心 5 秒，普通核心在 Rust 侧使用相同总预算。
+    private static readonly TimeSpan CoreShutdownTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan InitialServiceModeTunWaitTimeout = TimeSpan.FromSeconds(6);
     private static readonly TimeSpan InitialServiceModeStatusPollInterval = TimeSpan.FromMilliseconds(250);
 
@@ -219,7 +222,8 @@ public sealed partial class App : Avalonia.Application
                 HubStartupCoordinator.StopCoreAsync,
                 HubStartupCoordinator.ResumeCoreAsync,
                 (status, token) => StartCoreHostAsync(status, serviceModeManager, coreProcessCleaner, token),
-                isActive => _isServiceModeCoreHostActive = isActive);
+                isActive => _isServiceModeCoreHostActive = isActive,
+                isServiceModeActive: initialServiceModeStatus.IsRunning);
             var coreUpdater = new MihomoCoreUpdater(DesktopApplicationLayout.CoreBinaryPath, coreManager);
             var connectionPage = new ConnectionPageViewModel(proxyCoreClient, localization: localization);
             var proxyConfigSource = new FileRuntimeProxyConfigSource(platformDirectories.RuntimeDirectory, subscriptionSelectionStore);
@@ -341,6 +345,28 @@ public sealed partial class App : Avalonia.Application
             {
                 DataContext = viewModel
             };
+            mainWindow.PrepareShutdownAsync = async () =>
+            {
+                StopBackgroundServices();
+                AppLogger.Info("[Shutdown] Background schedulers stopped");
+                using var timeout = new CancellationTokenSource(CoreShutdownTimeout);
+                var serviceStopStartedAt = Stopwatch.GetTimestamp();
+                var result = await serviceModeSessionSwitcher.PrepareForShutdownAsync(timeout.Token);
+                if (!result.IsSuccess)
+                {
+                    AppLogger.Warning($"[Shutdown] Service-mode core stop failed elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
+                }
+                else
+                {
+                    AppLogger.Info($"[Shutdown] Service-mode core stop completed elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
+                }
+
+                var hubStopStartedAt = Stopwatch.GetTimestamp();
+                AppLogger.Info("[Shutdown] Normal-mode hub shutdown started");
+                await Task.Run(HubBootstrap.Shutdown);
+                AppLogger.Info($"[Shutdown] Normal-mode hub shutdown completed elapsed={Stopwatch.GetElapsedTime(hubStopStartedAt).TotalMilliseconds:0}ms");
+            };
+            mainWindow.OsShutdownDetected = () => Interlocked.Exchange(ref _isOsShutdownRequested, 1);
 #if DEBUG
             LogStartupTrace("Main window constructed and bound", startupStartedAt);
 #endif
@@ -360,18 +386,38 @@ public sealed partial class App : Avalonia.Application
 
             desktop.ShutdownRequested += (_, _) =>
             {
+                var isOsShutdown = Volatile.Read(ref _isOsShutdownRequested) != 0;
+                var source = mainWindow.IsShutdownPreparing
+                    ? "application"
+                    : isOsShutdown ? "os" : "external";
+                AppLogger.Info($"[Shutdown] Lifetime cleanup started (origin: {source})");
                 StopBackgroundServices();
+                AppLogger.Info("[Shutdown] System proxy cleanup started");
                 viewModel.HomePage.DisableSystemProxyOnShutdown();
+                AppLogger.Info("[Shutdown] System proxy cleanup completed");
                 _trayService.Dispose();
                 globalHotkeyService.Dispose();
                 _sessionEndCleanup?.Dispose();
                 _sessionEndCleanup = null;
                 viewModel.Dispose();
-                DisposeOwnedServices(serviceModeSessionSwitcher, coreManager, proxyCoreClient, proxyDelayTester, coreProviderClient, webDavBackupStore);
-                HubBootstrap.Shutdown();
+                var switcherDisposed = serviceModeSessionSwitcher.TryDisposeForShutdown();
+                var coreManagerDisposed = coreManager.TryDisposeForShutdown();
+                AppLogger.Info($"[Shutdown] Core ownership released switcher={switcherDisposed} manager={coreManagerDisposed}");
+                DisposeOwnedServices(proxyCoreClient, proxyDelayTester, coreProviderClient, webDavBackupStore);
+                if (OperatingSystem.IsWindows())
+                {
+                    AppLogger.Info("[Shutdown] Lifetime cleanup skipped synchronous hub wait; Job Object owns remaining normal core termination");
+                }
+                else
+                {
+                    HubBootstrap.Shutdown();
+                }
+                AppLogger.Info($"[Shutdown] Lifetime cleanup completed (origin: {source})");
             };
             // 兜底系统关机/注销：用户未主动退出时同步清理系统代理，避免残留失效端口。
-            _sessionEndCleanup = new SessionEndCleanupService(viewModel.HomePage.DisableSystemProxyOnShutdown);
+            _sessionEndCleanup = new SessionEndCleanupService(
+                viewModel.HomePage.DisableSystemProxyOnShutdown,
+                isDetected => Interlocked.Exchange(ref _isOsShutdownRequested, isDetected ? 1 : 0));
             _sessionEndCleanup.Start();
             _trayService.Attach(desktop, mainWindow, viewModel, localization);
             foreach (var (action, gesture) in new[]
@@ -548,6 +594,7 @@ public sealed partial class App : Avalonia.Application
                 cancellationToken);
             if (result.IsSuccess)
             {
+                _isServiceModeCoreHostActive = true;
                 AppLogger.Info("Service-mode core started");
                 return BootstrapResult.Success(result.Message);
             }

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -157,7 +157,7 @@ public sealed partial class App : Avalonia.Application
                 runtimeStore);
             var subscriptionDeleter = new SubscriptionDeleter(subscriptionStore, subscriptionSelectionStore, runtimeStore);
             // Provider 同步和状态读取始终走核心管道，保持 Debug 和 Release 路径一致。
-            var coreProviderClient = new PipeCoreProviderClient(HubStartupCoordinator.MihomoPipe);
+            var coreProviderClient = new PipeCoreProviderClient(HubStartupCoordinator.CorePipe);
             var providerCatalogLoader = new SelectedSubscriptionProviderCatalogLoader(
                 subscriptionStore,
                 subscriptionSelectionStore,
@@ -194,17 +194,17 @@ public sealed partial class App : Avalonia.Application
                 overrideFileOpener,
                 localization);
 #if DEBUG
-            var pipeProxyCoreClient = new PipeCoreProxyClient(HubStartupCoordinator.MihomoPipe);
+            var pipeProxyCoreClient = new PipeCoreProxyClient(HubStartupCoordinator.CorePipe);
             IProxyCoreClient proxyCoreClient = new ProxyCoreClient(pipeProxyCoreClient);
             IProxyDelayTester proxyDelayTester = new PipeCoreProxyDelayTester(
-                HubStartupCoordinator.MihomoPipe,
+                HubStartupCoordinator.CorePipe,
                 () => settings.DelayTestUrl,
                 5000);
 #else
 
-            IProxyCoreClient proxyCoreClient = new PipeCoreProxyClient(HubStartupCoordinator.MihomoPipe);
+            IProxyCoreClient proxyCoreClient = new PipeCoreProxyClient(HubStartupCoordinator.CorePipe);
             IProxyDelayTester proxyDelayTester = new PipeCoreProxyDelayTester(
-                HubStartupCoordinator.MihomoPipe,
+                HubStartupCoordinator.CorePipe,
                 () => settings.DelayTestUrl,
                 5000);
 #endif
@@ -224,13 +224,13 @@ public sealed partial class App : Avalonia.Application
                 (status, token) => StartCoreHostAsync(status, serviceModeManager, coreProcessCleaner, token),
                 isActive => _isServiceModeCoreHostActive = isActive,
                 isServiceModeActive: initialServiceModeStatus.IsRunning);
-            var coreUpdater = new MihomoCoreUpdater(DesktopApplicationLayout.CoreBinaryPath, coreManager);
             var connectionPage = new ConnectionPageViewModel(proxyCoreClient, localization: localization);
             var proxyConfigSource = new FileRuntimeProxyConfigSource(platformDirectories.RuntimeDirectory, subscriptionSelectionStore);
             var proxyConfigParser = new ProxyConfigParser();
             var proxyConfigLoader = new ProxyConfigLoader(
                 proxyConfigSource,
                 proxyConfigParser);
+            var fileRuntimeProxyConfigProvider = new FileRuntimeProxyConfigProvider(proxyConfigLoader);
             var proxySelectionSyncState = new ProxySelectionSyncState();
             var mihomoApiProxyConfigProvider = new MihomoApiProxyConfigProvider(
                 proxyCoreClient,
@@ -243,15 +243,23 @@ public sealed partial class App : Avalonia.Application
                 importCoreSelections: true,
                 pruneInvalidSelections: false);
             var fallbackProxyConfigProvider = new StoredProxySelectionConfigProvider(
-                new FileRuntimeProxyConfigProvider(proxyConfigLoader),
+                fileRuntimeProxyConfigProvider,
                 proxySelectionStore,
                 subscriptionSelectionStore,
                 pruneInvalidSelections: false);
             var proxySelectionRestorer = new ProxySelectionRestorer(
-                proxyCoreClient,
-                mihomoApiProxyConfigProvider,
-                primaryProxyConfigProvider,
-                proxySelectionSyncState);
+                coreClient: proxyCoreClient,
+                coreConfigProvider: mihomoApiProxyConfigProvider,
+                selectedRuntimeConfigProvider: fileRuntimeProxyConfigProvider,
+                selectionProvider: primaryProxyConfigProvider,
+                syncState: proxySelectionSyncState,
+                subscriptionSelectionStore: subscriptionSelectionStore);
+            var selectionRestoringCoreManager = new ProxySelectionRestoringCoreManager(
+                coreManager,
+                proxySelectionRestorer);
+            var coreUpdater = new MihomoCoreUpdater(
+                DesktopApplicationLayout.CoreBinaryPath,
+                selectionRestoringCoreManager);
             var proxyPageLayout = Enum.TryParse<ProxyPageLayout>(settings.ProxyPageLayout, ignoreCase: true, out var parsedProxyLayout)
                 ? parsedProxyLayout
                 : ProxyPageLayout.Horizontal;
@@ -312,7 +320,7 @@ public sealed partial class App : Avalonia.Application
                     overrideSelectionUpdater,
                     selectedSubscriptionRuntimeGenerator),
                 runtimeStore: runtimeStore,
-                coreManager: coreManager,
+                coreManager: selectionRestoringCoreManager,
                 initialSettings: settings,
                 windowEffectCapability: new WindowEffectCapability(),
                 networkConnectionProbe: networkConnectionProbe,
@@ -322,8 +330,20 @@ public sealed partial class App : Avalonia.Application
                 initialServiceModeStatus: initialServiceModeStatus,
                 systemPlatform: systemProxyPlatform,
                 clipboardWriter: clipboardWriter,
-                serviceModeSessionActivator: serviceModeSessionSwitcher.ActivateAsync,
-                serviceModeSessionDeactivator: serviceModeSessionSwitcher.DeactivateAsync,
+                serviceModeSessionActivator: token => selectionRestoringCoreManager.RunCoreResetAsync(
+                    "service-mode-activation",
+                    serviceModeSessionSwitcher.ActivateAsync,
+                    token),
+                serviceModeSessionDeactivator: token => selectionRestoringCoreManager.RunCoreResetAsync(
+                    "service-mode-deactivation",
+                    serviceModeSessionSwitcher.DeactivateAsync,
+                    token),
+                serviceModeCoreTransitionStarting: () =>
+                    selectionRestoringCoreManager.NotifyCoreResetStarting("service-mode-operation"),
+                serviceModeCoreTransitionCompleted: _ =>
+                    selectionRestoringCoreManager.RestoreCurrentCoreSelectionsAsync(
+                        "service-mode-operation-completion",
+                        CancellationToken.None),
                 appLogReader: new FileAppLogReader(DesktopApplicationLayout.RunningLogFilePath),
                 appLogExporter: new FileAppLogExporter(DesktopApplicationLayout.RunningLogFilePath));
             hotkeyViewModel = viewModel;
@@ -348,23 +368,23 @@ public sealed partial class App : Avalonia.Application
             mainWindow.PrepareShutdownAsync = async () =>
             {
                 StopBackgroundServices();
-                AppLogger.Info("[Shutdown] Background schedulers stopped");
+                AppLogger.Info("Background schedulers stopped for shutdown");
                 using var timeout = new CancellationTokenSource(CoreShutdownTimeout);
                 var serviceStopStartedAt = Stopwatch.GetTimestamp();
                 var result = await serviceModeSessionSwitcher.PrepareForShutdownAsync(timeout.Token);
                 if (!result.IsSuccess)
                 {
-                    AppLogger.Warning($"[Shutdown] Service-mode core stop failed elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
+                    AppLogger.Warning($"Service-mode core stop failed: elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
                 }
                 else
                 {
-                    AppLogger.Info($"[Shutdown] Service-mode core stop completed elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
+                    AppLogger.Info($"Service-mode core stop completed: elapsed={Stopwatch.GetElapsedTime(serviceStopStartedAt).TotalMilliseconds:0}ms message={result.Message}");
                 }
 
                 var hubStopStartedAt = Stopwatch.GetTimestamp();
-                AppLogger.Info("[Shutdown] Normal-mode hub shutdown started");
+                AppLogger.Info("Normal-mode hub shutdown started");
                 await Task.Run(HubBootstrap.Shutdown);
-                AppLogger.Info($"[Shutdown] Normal-mode hub shutdown completed elapsed={Stopwatch.GetElapsedTime(hubStopStartedAt).TotalMilliseconds:0}ms");
+                AppLogger.Info($"Normal-mode hub shutdown completed: elapsed={Stopwatch.GetElapsedTime(hubStopStartedAt).TotalMilliseconds:0}ms");
             };
             mainWindow.OsShutdownDetected = () => Interlocked.Exchange(ref _isOsShutdownRequested, 1);
 #if DEBUG
@@ -390,11 +410,11 @@ public sealed partial class App : Avalonia.Application
                 var source = mainWindow.IsShutdownPreparing
                     ? "application"
                     : isOsShutdown ? "os" : "external";
-                AppLogger.Info($"[Shutdown] Lifetime cleanup started (origin: {source})");
+                AppLogger.Info($"Lifetime cleanup started: origin={source}");
                 StopBackgroundServices();
-                AppLogger.Info("[Shutdown] System proxy cleanup started");
+                AppLogger.Info("System proxy shutdown cleanup started");
                 viewModel.HomePage.DisableSystemProxyOnShutdown();
-                AppLogger.Info("[Shutdown] System proxy cleanup completed");
+                AppLogger.Info("System proxy shutdown cleanup completed");
                 _trayService.Dispose();
                 globalHotkeyService.Dispose();
                 _sessionEndCleanup?.Dispose();
@@ -402,17 +422,17 @@ public sealed partial class App : Avalonia.Application
                 viewModel.Dispose();
                 var switcherDisposed = serviceModeSessionSwitcher.TryDisposeForShutdown();
                 var coreManagerDisposed = coreManager.TryDisposeForShutdown();
-                AppLogger.Info($"[Shutdown] Core ownership released switcher={switcherDisposed} manager={coreManagerDisposed}");
-                DisposeOwnedServices(proxyCoreClient, proxyDelayTester, coreProviderClient, webDavBackupStore);
+                AppLogger.Info($"Core ownership released for shutdown: switcher={switcherDisposed} manager={coreManagerDisposed}");
+                DisposeOwnedServices(selectionRestoringCoreManager, proxyCoreClient, proxyDelayTester, coreProviderClient, webDavBackupStore);
                 if (OperatingSystem.IsWindows())
                 {
-                    AppLogger.Info("[Shutdown] Lifetime cleanup skipped synchronous hub wait; Job Object owns remaining normal core termination");
+                    AppLogger.Info("Lifetime cleanup skipped synchronous hub wait; Job Object owns remaining normal core termination");
                 }
                 else
                 {
                     HubBootstrap.Shutdown();
                 }
-                AppLogger.Info($"[Shutdown] Lifetime cleanup completed (origin: {source})");
+                AppLogger.Info($"Lifetime cleanup completed: origin={source}");
             };
             // 兜底系统关机/注销：用户未主动退出时同步清理系统代理，避免残留失效端口。
             _sessionEndCleanup = new SessionEndCleanupService(
@@ -695,7 +715,7 @@ public sealed partial class App : Avalonia.Application
         {
             return new ServiceModeCoreManager(
                 serviceModeManager,
-                HubStartupCoordinator.MihomoPipe,
+                HubStartupCoordinator.CorePipe,
                 HubStartupCoordinator.WriteServiceModeActiveConfig,
                 isActive => _isServiceModeCoreHostActive = isActive);
         }

--- a/src/Stelliberty.Desktop/Debug/Commands/App.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/App.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input.Platform;
 using Avalonia.VisualTree;
 
@@ -51,10 +50,6 @@ internal static partial class DebugCommands
         if (string.Equals(command, "app.quit", StringComparison.OrdinalIgnoreCase))
         {
             window.RequestShutdown();
-            if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-            {
-                desktop.TryShutdown(0);
-            }
             return null;
         }
 

--- a/src/Stelliberty.Desktop/Debug/Commands/Proxies.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Proxies.cs
@@ -9,6 +9,8 @@ internal static partial class DebugCommands
     {
         var viewModel = RequireViewModel(window);
         var page = viewModel.ProxyPage;
+        // 非当前页会释放行缓存，调试命令读取前按现有展示生命周期重建。
+        page.WarmupPresentation();
         var spec = command["proxies.".Length..].Trim();
         if (string.Equals(spec, "list_groups", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Stelliberty.Desktop/HubStartupCoordinator.cs
+++ b/src/Stelliberty.Desktop/HubStartupCoordinator.cs
@@ -16,13 +16,14 @@ namespace Stelliberty.Desktop;
 // 只编排普通模式启动；启动配置策略归 Application。
 internal static class HubStartupCoordinator
 {
+    // 端点标识沿用 mihomo，确保升级后仍能连接旧服务托管的核心。
 #if DEBUG
 
     public static readonly string PipeName = BuildHubEndpoint(AppMetadata.PipePrefix + "_core_dev");
-    public static readonly string MihomoPipe = BuildMihomoEndpoint(AppMetadata.PipePrefix + "_mihomo_dev");
+    public static readonly string CorePipe = BuildCoreEndpoint(AppMetadata.PipePrefix + "_mihomo_dev");
 #else
     public static readonly string PipeName = BuildHubEndpoint(AppMetadata.PipePrefix + "_core_prod");
-    public static readonly string MihomoPipe = BuildMihomoEndpoint(AppMetadata.PipePrefix + "_mihomo_prod");
+    public static readonly string CorePipe = BuildCoreEndpoint(AppMetadata.PipePrefix + "_mihomo_prod");
 #endif
 
     private static readonly object StartGate = new();
@@ -61,10 +62,10 @@ internal static class HubStartupCoordinator
     {
         return new BootstrapOptions(
             PipeName: PipeName,
-            MihomoPath: DesktopApplicationLayout.CoreBinaryPath,
+            CorePath: DesktopApplicationLayout.CoreBinaryPath,
             DataCoreDir: DesktopApplicationLayout.CoreDirectory,
             UserDataDir: DesktopApplicationLayout.AppDataDirectory,
-            MihomoPipe: MihomoPipe,
+            CorePipe: CorePipe,
             BootstrapYaml: BuildInitialBootstrapYaml(CanNormalModeUseTun()));
     }
 
@@ -86,7 +87,7 @@ internal static class HubStartupCoordinator
     {
         Directory.CreateDirectory(DesktopApplicationLayout.RuntimeDirectory);
         var path = Path.Combine(DesktopApplicationLayout.RuntimeDirectory, "_service_active.yaml");
-        File.WriteAllText(path, InjectMihomoPipe(content));
+        File.WriteAllText(path, InjectCorePipe(content));
         return path;
     }
 
@@ -113,18 +114,18 @@ internal static class HubStartupCoordinator
                         overrideStore,
                         runtimeStore)),
                 new SubscriptionFailureRecorder(subscriptionStore));
-            return builder.Build(MihomoPipe, canUseTun);
+            return builder.Build(CorePipe, canUseTun);
         }
         catch (Exception exception)
         {
             AppLogger.Warning($"Startup config generation failed; starting core with an empty config: {exception.Message}");
-            return StartupBootstrapConfigBuilder.BuildDefaultEmptyYaml(MihomoPipe);
+            return StartupBootstrapConfigBuilder.BuildDefaultEmptyYaml(CorePipe);
         }
     }
 
-    private static string InjectMihomoPipe(string content)
+    private static string InjectCorePipe(string content)
     {
-        return ServiceModeRuntimeConfigWriter.Write(content, MihomoPipe);
+        return ServiceModeRuntimeConfigWriter.Write(content, CorePipe);
     }
 
     private static bool CanNormalModeUseTun()
@@ -132,7 +133,7 @@ internal static class HubStartupCoordinator
         return AppSettingsNormalizer.CanUseTun(new SystemProcessPrivilegeProbe().Detect(), hasServiceTunHost: false);
     }
 
-    private static string BuildMihomoEndpoint(string name)
+    private static string BuildCoreEndpoint(string name)
     {
         return OperatingSystem.IsWindows()
             ? $@"\\.\pipe\{name}"

--- a/src/Stelliberty.Desktop/MainWindow.axaml.cs
+++ b/src/Stelliberty.Desktop/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -44,6 +45,7 @@ public sealed partial class MainWindow : Window
     private MainWindowViewModel? _attachedViewModel;
     private AccentColorPickerView? _activeAccentPicker;
     private bool _isShutdownRequested;
+    private bool _isShutdownPreparing;
     private bool _hasOpened;
     private long _pageTransitionVersion;
     private long _pageLoadingShownAt;
@@ -765,23 +767,76 @@ public sealed partial class MainWindow : Window
 
     public void RequestShutdown()
     {
-        _isShutdownRequested = true;
-        Close();
+        if (_isShutdownRequested || _isShutdownPreparing)
+        {
+            return;
+        }
+
+        AppLogger.Info("[Shutdown] Application exit requested");
+        _isShutdownPreparing = true;
+        _ = PrepareAndShutdownAsync();
     }
+
+    internal Func<Task>? PrepareShutdownAsync { private get; set; }
+
+    internal Action? OsShutdownDetected { private get; set; }
+
+    internal bool IsShutdownPreparing => _isShutdownPreparing;
 
     protected override void OnClosing(WindowClosingEventArgs args)
     {
         _windowStateService.SaveNow();
-        if (!_isShutdownRequested && DataContext is MainWindowViewModel { AppBehavior.IsMinimizeToTrayEnabled: true })
+        if (args.CloseReason == WindowCloseReason.OSShutdown)
+        {
+            OsShutdownDetected?.Invoke();
+            AppLogger.Info("[Shutdown] OS window close accepted without cancellation");
+            base.OnClosing(args);
+            return;
+        }
+
+        if (!_isShutdownRequested)
         {
             args.Cancel = true;
-            ClearTitleBarHoverState();
-            // 先取消关闭按钮红色效果，等界面更新两次再隐藏，避免恢复窗口时闪红。
-            RequestAnimationFrame(OnTitleBarStateClearedFrame);
+            if (DataContext is MainWindowViewModel { AppBehavior.IsMinimizeToTrayEnabled: true })
+            {
+                ClearTitleBarHoverState();
+                // 先取消关闭按钮红色效果，等界面更新两次再隐藏，避免恢复窗口时闪红。
+                RequestAnimationFrame(OnTitleBarStateClearedFrame);
+            }
+            else
+            {
+                RequestShutdown();
+            }
             return;
         }
 
         base.OnClosing(args);
+    }
+
+    private async Task PrepareAndShutdownAsync()
+    {
+        AppLogger.Info("[Shutdown] Application exit preparation started");
+        try
+        {
+            if (PrepareShutdownAsync is not null)
+            {
+                await PrepareShutdownAsync();
+            }
+        }
+        catch (Exception exception)
+        {
+            AppLogger.Warning($"[Shutdown] Application exit preparation failed: {exception.Message}");
+        }
+
+        AppLogger.Info("[Shutdown] Application exit preparation completed");
+        var desktop = Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+        var requiresExplicitShutdown = desktop?.ShutdownMode == ShutdownMode.OnExplicitShutdown;
+        _isShutdownRequested = true;
+        Close();
+        if (requiresExplicitShutdown)
+        {
+            desktop?.TryShutdown(0);
+        }
     }
 
     protected override void OnClosed(EventArgs e)

--- a/src/Stelliberty.Desktop/MainWindow.axaml.cs
+++ b/src/Stelliberty.Desktop/MainWindow.axaml.cs
@@ -32,6 +32,7 @@ public sealed partial class MainWindow : Window
     private readonly WindowAppearanceService _windowAppearanceService = new();
     private readonly WindowStateService _windowStateService;
     private readonly SystemAccentColorService _systemAccentColorService = new();
+    private readonly BitmapCache _proxyPageBitmapCache = new() { SnapsToDevicePixels = true };
     private readonly Dictionary<AppNavigationPage, ContentControl> _pageHosts = new();
     private readonly Dictionary<AppNavigationPage, Dictionary<string, Vector>> _pageScrollOffsets = new();
     private IReadOnlyDictionary<SettingsSubPage, Vector> _settingsScrollOffsets = new Dictionary<SettingsSubPage, Vector>();
@@ -211,6 +212,8 @@ public sealed partial class MainWindow : Window
             _pageHosts[AppNavigationPage.Subscriptions] = SubscriptionsPageHost;
             _pageHosts[AppNavigationPage.Overrides] = OverridesPageHost;
             _pageHosts[AppNavigationPage.Settings] = SettingsPageHost;
+            // 代理页作为单层纹理参与整页变换，避免动画期间重复绘制大视觉树。
+            ProxyPageHost.CacheMode = _proxyPageBitmapCache;
             _pageHostsReady = true;
         }
 

--- a/src/Stelliberty.Desktop/MainWindow.axaml.cs
+++ b/src/Stelliberty.Desktop/MainWindow.axaml.cs
@@ -772,7 +772,7 @@ public sealed partial class MainWindow : Window
             return;
         }
 
-        AppLogger.Info("[Shutdown] Application exit requested");
+        AppLogger.Info("Application exit requested");
         _isShutdownPreparing = true;
         _ = PrepareAndShutdownAsync();
     }
@@ -789,7 +789,7 @@ public sealed partial class MainWindow : Window
         if (args.CloseReason == WindowCloseReason.OSShutdown)
         {
             OsShutdownDetected?.Invoke();
-            AppLogger.Info("[Shutdown] OS window close accepted without cancellation");
+            AppLogger.Info("OS window close accepted without cancellation");
             base.OnClosing(args);
             return;
         }
@@ -815,7 +815,7 @@ public sealed partial class MainWindow : Window
 
     private async Task PrepareAndShutdownAsync()
     {
-        AppLogger.Info("[Shutdown] Application exit preparation started");
+        AppLogger.Info("Application exit preparation started");
         try
         {
             if (PrepareShutdownAsync is not null)
@@ -825,10 +825,10 @@ public sealed partial class MainWindow : Window
         }
         catch (Exception exception)
         {
-            AppLogger.Warning($"[Shutdown] Application exit preparation failed: {exception.Message}");
+            AppLogger.Warning($"Application exit preparation failed: {exception.Message}");
         }
 
-        AppLogger.Info("[Shutdown] Application exit preparation completed");
+        AppLogger.Info("Application exit preparation completed");
         var desktop = Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
         var requiresExplicitShutdown = desktop?.ShutdownMode == ShutdownMode.OnExplicitShutdown;
         _isShutdownRequested = true;

--- a/src/Stelliberty.Desktop/MainWindow.axaml.cs
+++ b/src/Stelliberty.Desktop/MainWindow.axaml.cs
@@ -305,8 +305,11 @@ public sealed partial class MainWindow : Window
 
         if (nextHost.Content is not null)
         {
+            // 缓存页已有视觉树，直接启动过渡，避免等待空闲合成器唤醒。
             PrepareNextHostEnterState(nextHost);
-            RequestPagePreparationFrame(previousHost, nextHost, page, version, enforceMinLoading: false);
+            ActivatePageHost(nextHost);
+            PreparePageLayout(page, nextHost);
+            StartPageTransition(previousHost, nextHost, version);
             return;
         }
 
@@ -348,7 +351,7 @@ public sealed partial class MainWindow : Window
 
                                 EnsurePageLoaded(page);
                                 PrepareNextHostEnterState(nextHost);
-                                RequestPagePreparationFrame(previousHost, nextHost, page, version, enforceMinLoading: true);
+                                RequestPagePreparationFrame(previousHost, nextHost, page, version);
                             },
                             DispatcherPriority.Background);
                     });
@@ -370,8 +373,7 @@ public sealed partial class MainWindow : Window
         ContentControl? previousHost,
         ContentControl nextHost,
         AppNavigationPage page,
-        long version,
-        bool enforceMinLoading)
+        long version)
     {
         RequestAnimationFrame(
             _ =>
@@ -383,22 +385,21 @@ public sealed partial class MainWindow : Window
 
                 ActivatePageHost(nextHost);
                 PreparePageLayout(page, nextHost);
-                CompletePageLoadingThenEnter(previousHost, nextHost, version, enforceMinLoading);
+                CompletePageLoadingThenEnter(previousHost, nextHost, version);
             });
     }
 
     private void CompletePageLoadingThenEnter(
         ContentControl? previousHost,
         ContentControl nextHost,
-        long version,
-        bool enforceMinLoading)
+        long version)
     {
         if (version != _pageTransitionVersion || !ReferenceEquals(_pendingPageHost, nextHost))
         {
             return;
         }
 
-        if (!enforceMinLoading || _pageLoadingShownAt == 0)
+        if (_pageLoadingShownAt == 0)
         {
             RequestAnimationFrame(_ => StartPageTransition(previousHost, nextHost, version));
             return;

--- a/src/Stelliberty.Desktop/ServiceModeRuntimeConfigWriter.cs
+++ b/src/Stelliberty.Desktop/ServiceModeRuntimeConfigWriter.cs
@@ -5,7 +5,7 @@ namespace Stelliberty.Desktop;
 
 internal static class ServiceModeRuntimeConfigWriter
 {
-    public static string Write(string content, string mihomoPipe)
+    public static string Write(string content, string corePipe)
     {
         var stream = new YamlStream();
         using var reader = new StringReader(content);
@@ -16,7 +16,7 @@ internal static class ServiceModeRuntimeConfigWriter
 
         var controllerKey = OperatingSystem.IsWindows() ? "external-controller-pipe" : "external-controller-unix";
         var staleControllerKey = OperatingSystem.IsWindows() ? "external-controller-unix" : "external-controller-pipe";
-        Set(root, controllerKey, mihomoPipe);
+        Set(root, controllerKey, corePipe);
         Remove(root, staleControllerKey);
 
         var output = new StringBuilder();

--- a/src/Stelliberty.Desktop/Services/CorePipeLogStreamer.cs
+++ b/src/Stelliberty.Desktop/Services/CorePipeLogStreamer.cs
@@ -9,7 +9,7 @@ using Stelliberty.Domain.CoreLogs;
 
 namespace Stelliberty.Desktop.Services;
 
-internal sealed class MihomoPipeLogStreamer : IDisposable
+internal sealed class CorePipeLogStreamer : IDisposable
 {
     private const int MaxFrameBytes = 1024 * 1024;
     private static readonly TimeSpan ReconnectDelay = TimeSpan.FromSeconds(2);
@@ -21,9 +21,9 @@ internal sealed class MihomoPipeLogStreamer : IDisposable
     private Task? _streamTask;
     private bool _isDisposed;
 
-    public MihomoPipeLogStreamer(string mihomoPipe)
+    public CorePipeLogStreamer(string corePipe)
     {
-        _pipeName = NormalizeEndpoint(mihomoPipe);
+        _pipeName = NormalizeEndpoint(corePipe);
     }
 
     public event EventHandler<CoreLogMessage>? MessageReceived;
@@ -326,7 +326,7 @@ internal sealed class MihomoPipeLogStreamer : IDisposable
         {
             if (!Path.IsPathRooted(pipeName))
             {
-                throw new InvalidOperationException("mihomo Unix socket path must be absolute.");
+                throw new InvalidOperationException("Core Unix socket path must be absolute.");
             }
 
             await socket.ConnectAsync(new UnixDomainSocketEndPoint(pipeName), cancellationToken).ConfigureAwait(false);

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -170,7 +170,7 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         var payload = JsonSerializer.Serialize(
             new StartCoreCommand(
                 new StartCorePayload(
-                    request.MihomoPath,
+                    request.CorePath,
                     request.ConfigPath,
                     request.DataCoreDir)));
         return RunServiceCommandAsync("start-core", false, ManageTimeout, cancellationToken, payload);
@@ -619,8 +619,9 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         public string Type => "StartCore";
     }
 
+    // 服务协议字段保留 mihomo_path，兼容已安装的旧服务。
     private sealed record StartCorePayload(
-        [property: JsonPropertyName("mihomo_path")] string MihomoPath,
+        [property: JsonPropertyName("mihomo_path")] string CorePath,
         [property: JsonPropertyName("config_path")] string ConfigPath,
         [property: JsonPropertyName("data_core_dir")] string DataCoreDir);
 }

--- a/src/Stelliberty.Desktop/Services/DesktopTrayService.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopTrayService.cs
@@ -352,7 +352,6 @@ internal sealed class DesktopTrayService : IDisposable
     private void OnExitClicked(object? sender, EventArgs args)
     {
         _window?.RequestShutdown();
-        _desktop?.TryShutdown(0);
     }
 
     private void OnLanguageChanged(object? sender, EventArgs args) => UpdateText();

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -15,8 +15,8 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     private static readonly TimeSpan StatePollInterval = TimeSpan.FromSeconds(2);
 
     private readonly IServiceModeManager _serviceModeManager;
-    private readonly HttpClient _mihomoClient;
-    private readonly MihomoPipeLogStreamer _logStreamer;
+    private readonly HttpClient _coreClient;
+    private readonly CorePipeLogStreamer _logStreamer;
     private readonly Func<string, string> _writeActiveConfig;
     private readonly Action<bool> _setCoreHostActive;
     private readonly object _monitorGate = new();
@@ -27,13 +27,13 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
 
     public ServiceModeCoreManager(
         IServiceModeManager serviceModeManager,
-        string mihomoPipe,
+        string corePipe,
         Func<string, string> writeActiveConfig,
         Action<bool> setCoreHostActive)
     {
         _serviceModeManager = serviceModeManager;
-        _mihomoClient = PipeCoreProxyClient.CreatePipeHttpClient(mihomoPipe);
-        _logStreamer = new MihomoPipeLogStreamer(mihomoPipe);
+        _coreClient = PipeCoreProxyClient.CreatePipeHttpClient(corePipe);
+        _logStreamer = new CorePipeLogStreamer(corePipe);
         _logStreamer.MessageReceived += OnLogMessageReceived;
         _writeActiveConfig = writeActiveConfig;
         _setCoreHostActive = setCoreHostActive;
@@ -54,7 +54,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         StopStatusMonitor();
         _logStreamer.MessageReceived -= OnLogMessageReceived;
         _logStreamer.Dispose();
-        _mihomoClient.Dispose();
+        _coreClient.Dispose();
     }
 
     public async Task<CoreSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
@@ -194,7 +194,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
             }
             catch (Exception exception)
             {
-                PublishSnapshot(new CoreSnapshot(CoreState.Unavailable, null, HubStartupCoordinator.MihomoPipe, exception.Message));
+                PublishSnapshot(new CoreSnapshot(CoreState.Unavailable, null, HubStartupCoordinator.CorePipe, exception.Message));
             }
         }
     }
@@ -223,7 +223,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
 
     private void PublishState(CoreState state, int? pid, string? lastError)
     {
-        PublishSnapshot(new CoreSnapshot(state, pid, HubStartupCoordinator.MihomoPipe, lastError));
+        PublishSnapshot(new CoreSnapshot(state, pid, HubStartupCoordinator.CorePipe, lastError));
     }
 
     private void PublishSnapshot(CoreSnapshot snapshot)
@@ -251,7 +251,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     {
         try
         {
-            using var response = await _mihomoClient.GetAsync("version", cancellationToken).ConfigureAwait(false);
+            using var response = await _coreClient.GetAsync("version", cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 return null;
@@ -291,7 +291,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         return new CoreSnapshot(
             ParseCoreState(status.CoreState),
             status.CorePid,
-            HubStartupCoordinator.MihomoPipe,
+            HubStartupCoordinator.CorePipe,
             status.CoreLastError);
     }
 }

--- a/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
@@ -13,11 +13,13 @@ internal sealed class ServiceModeSessionSwitcher(
     Func<CancellationToken, Task<BootstrapResult>> stopNormalCore,
     Func<CancellationToken, Task<BootstrapResult>> resumeNormalCore,
     Func<ServiceModeStatus, CancellationToken, Task<BootstrapResult>> startServiceCore,
-    Action<bool> setServiceModeCoreHostActive) : IDisposable
+    Action<bool> setServiceModeCoreHostActive,
+    bool isServiceModeActive = false) : IDisposable
 {
     private readonly object _lifetimeGate = new();
     private readonly SemaphoreSlim _operationGate = new(1, 1);
     private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private bool _isServiceModeActive = isServiceModeActive;
     private bool _isDisposed;
 
     public Task<ServiceModeOperationResult> ActivateAsync(CancellationToken cancellationToken)
@@ -28,6 +30,63 @@ internal sealed class ServiceModeSessionSwitcher(
     public Task<ServiceModeOperationResult> DeactivateAsync(CancellationToken cancellationToken)
     {
         return RunOperationAsync(DeactivateCoreAsync, cancellationToken);
+    }
+
+    public async Task<ServiceModeOperationResult> PrepareForShutdownAsync(CancellationToken cancellationToken)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed)
+            {
+                return ServiceModeOperationResult.Canceled("Service mode session is already shut down.");
+            }
+
+            // 退出后不再接受模式切换，避免停止核心后又被并发操作拉起。
+            _lifetimeCancellation.Cancel();
+        }
+
+        try
+        {
+            await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return ServiceModeOperationResult.Canceled("Service mode shutdown timed out.");
+        }
+
+        try
+        {
+            if (!_isServiceModeActive)
+            {
+                return ServiceModeOperationResult.Success("Normal mode does not require service-core shutdown.");
+            }
+
+            ServiceModeOperationResult result;
+            try
+            {
+                result = await serviceModeManager.StopCoreHostAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return ServiceModeOperationResult.Canceled("Service-mode core shutdown timed out.");
+            }
+            catch (Exception exception)
+            {
+                return ServiceModeOperationResult.Failed(exception.Message);
+            }
+
+            if (result.IsSuccess)
+            {
+                _isServiceModeActive = false;
+                setServiceModeCoreHostActive(false);
+            }
+
+            return result;
+        }
+        finally
+        {
+            _operationGate.Release();
+        }
     }
 
     public void Dispose()
@@ -45,6 +104,29 @@ internal sealed class ServiceModeSessionSwitcher(
 
         _operationGate.Wait();
         _lifetimeCancellation.Dispose();
+    }
+
+    public bool TryDisposeForShutdown()
+    {
+        lock (_lifetimeGate)
+        {
+            if (_isDisposed)
+            {
+                return true;
+            }
+
+            _isDisposed = true;
+            _lifetimeCancellation.Cancel();
+        }
+
+        // 退出事件不得再次等待已经超时的模式切换，未完成资源随进程回收。
+        if (!_operationGate.Wait(0))
+        {
+            return false;
+        }
+
+        _lifetimeCancellation.Dispose();
+        return true;
     }
 
     private async Task<ServiceModeOperationResult> RunOperationAsync(
@@ -165,6 +247,7 @@ internal sealed class ServiceModeSessionSwitcher(
                     ServiceModeOperationResult.Failed(started.Message)).ConfigureAwait(false);
             }
 
+            _isServiceModeActive = true;
             setServiceModeCoreHostActive(true);
             await transition.SwitchAsync(createServiceCoreManager(status), cancellationToken).ConfigureAwait(false);
             return ServiceModeOperationResult.Success("Service mode is active.");
@@ -212,6 +295,7 @@ internal sealed class ServiceModeSessionSwitcher(
             var readinessFailure = await transition.SwitchEvenIfUnavailableAsync(
                 createNormalCoreManager(),
                 CancellationToken.None).ConfigureAwait(false);
+            _isServiceModeActive = false;
             setServiceModeCoreHostActive(false);
             return readinessFailure is null
                 ? ServiceModeOperationResult.Success("Normal mode is active.")
@@ -246,6 +330,7 @@ internal sealed class ServiceModeSessionSwitcher(
             return ServiceModeOperationResult.Failed($"{result.Message} Normal-mode recovery was skipped: {exception.Message}");
         }
 
+        _isServiceModeActive = false;
         setServiceModeCoreHostActive(false);
         try
         {

--- a/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
@@ -210,7 +210,7 @@ internal sealed class ServiceModeSessionSwitcher(
         }
 
         using var ownedTransition = transition;
-        // 两种核心共用 Mihomo 管道，整段切换期间不允许其它核心操作进入。
+        // 两种核心共用控制管道，整段切换期间不允许其它核心操作进入。
         BootstrapResult stopped;
         try
         {

--- a/src/Stelliberty.Desktop/Services/SessionEndCleanupService.cs
+++ b/src/Stelliberty.Desktop/Services/SessionEndCleanupService.cs
@@ -6,7 +6,7 @@ namespace Stelliberty.Desktop.Services;
 
 // 系统关机/注销时同步清理系统代理，兜底用户未主动退出（如托盘常驻）的场景。
 // 关机会强杀进程，异步回调来不及，故清理必须在会话结束消息/信号里同步完成。
-public sealed class SessionEndCleanupService(Action cleanup) : IDisposable
+public sealed class SessionEndCleanupService(Action cleanup, Action<bool>? shutdownStateChanged = null) : IDisposable
 {
     private readonly List<IDisposable> _signalRegistrations = [];
     private WindowsSessionWatcher? _windowsWatcher;
@@ -16,7 +16,7 @@ public sealed class SessionEndCleanupService(Action cleanup) : IDisposable
     {
         if (OperatingSystem.IsWindows())
         {
-            _windowsWatcher = WindowsSessionWatcher.Create(RunCleanup);
+            _windowsWatcher = WindowsSessionWatcher.Create(RunCleanup, SetShutdownDetected);
             return;
         }
 
@@ -40,14 +40,22 @@ public sealed class SessionEndCleanupService(Action cleanup) : IDisposable
 
     private void RunCleanup()
     {
+        SetShutdownDetected(true);
+        AppLogger.Info("[Shutdown] Session-end cleanup started");
         try
         {
             cleanup();
+            AppLogger.Info("[Shutdown] Session-end cleanup completed");
         }
         catch (Exception exception)
         {
-            AppLogger.Warning($"Session-end cleanup failed: {exception.Message}");
+            AppLogger.Warning($"[Shutdown] Session-end cleanup failed: {exception.Message}");
         }
+    }
+
+    private void SetShutdownDetected(bool isDetected)
+    {
+        shutdownStateChanged?.Invoke(isDetected);
     }
 
     public void Dispose()
@@ -80,23 +88,25 @@ public sealed class SessionEndCleanupService(Action cleanup) : IDisposable
         private const uint WmEndSession = 0x0016;
 
         private readonly Action _cleanup;
+        private readonly Action<bool> _shutdownStateChanged;
         private readonly WndProc _wndProc; // 保持委托引用，防 GC 回收后回调悬空
         private readonly string _className;
         private readonly IntPtr _instance;
         private IntPtr _hwnd;
         private ushort _classAtom;
 
-        private WindowsSessionWatcher(Action cleanup)
+        private WindowsSessionWatcher(Action cleanup, Action<bool> shutdownStateChanged)
         {
             _cleanup = cleanup;
+            _shutdownStateChanged = shutdownStateChanged;
             _wndProc = HandleMessage;
             _className = $"StellibertySessionWatcher_{Environment.ProcessId}";
             _instance = GetModuleHandle(null);
         }
 
-        public static WindowsSessionWatcher? Create(Action cleanup)
+        public static WindowsSessionWatcher? Create(Action cleanup, Action<bool> shutdownStateChanged)
         {
-            var watcher = new WindowsSessionWatcher(cleanup);
+            var watcher = new WindowsSessionWatcher(cleanup, shutdownStateChanged);
             return watcher.Initialize() ? watcher : null;
         }
 
@@ -131,15 +141,25 @@ public sealed class SessionEndCleanupService(Action cleanup) : IDisposable
 
         private IntPtr HandleMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
-            // wParam 非零才是会话确实结束，被其他应用取消的关机不清理。
-            if (msg == WmEndSession && wParam != IntPtr.Zero)
+            if (msg == WmEndSession)
             {
-                _cleanup();
+                if (wParam != IntPtr.Zero)
+                {
+                    AppLogger.Info("[Shutdown] WM_ENDSESSION confirmed");
+                    _cleanup();
+                }
+                else
+                {
+                    _shutdownStateChanged(false);
+                    AppLogger.Info("[Shutdown] WM_ENDSESSION canceled");
+                }
                 return IntPtr.Zero;
             }
 
             if (msg == WmQueryEndSession)
             {
+                _shutdownStateChanged(true);
+                AppLogger.Info("[Shutdown] WM_QUERYENDSESSION accepted");
                 return 1; // 允许会话结束
             }
 

--- a/src/Stelliberty.Desktop/Services/SessionEndCleanupService.cs
+++ b/src/Stelliberty.Desktop/Services/SessionEndCleanupService.cs
@@ -41,15 +41,15 @@ public sealed class SessionEndCleanupService(Action cleanup, Action<bool>? shutd
     private void RunCleanup()
     {
         SetShutdownDetected(true);
-        AppLogger.Info("[Shutdown] Session-end cleanup started");
+        AppLogger.Info("Session-end cleanup started");
         try
         {
             cleanup();
-            AppLogger.Info("[Shutdown] Session-end cleanup completed");
+            AppLogger.Info("Session-end cleanup completed");
         }
         catch (Exception exception)
         {
-            AppLogger.Warning($"[Shutdown] Session-end cleanup failed: {exception.Message}");
+            AppLogger.Warning($"Session-end cleanup failed: {exception.Message}");
         }
     }
 
@@ -145,13 +145,13 @@ public sealed class SessionEndCleanupService(Action cleanup, Action<bool>? shutd
             {
                 if (wParam != IntPtr.Zero)
                 {
-                    AppLogger.Info("[Shutdown] WM_ENDSESSION confirmed");
+                    AppLogger.Info("WM_ENDSESSION confirmed");
                     _cleanup();
                 }
                 else
                 {
                     _shutdownStateChanged(false);
-                    AppLogger.Info("[Shutdown] WM_ENDSESSION canceled");
+                    AppLogger.Info("WM_ENDSESSION canceled");
                 }
                 return IntPtr.Zero;
             }
@@ -159,7 +159,7 @@ public sealed class SessionEndCleanupService(Action cleanup, Action<bool>? shutd
             if (msg == WmQueryEndSession)
             {
                 _shutdownStateChanged(true);
-                AppLogger.Info("[Shutdown] WM_QUERYENDSESSION accepted");
+                AppLogger.Info("WM_QUERYENDSESSION accepted");
                 return 1; // 允许会话结束
             }
 

--- a/src/Stelliberty.Desktop/Services/SwitchableCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/SwitchableCoreManager.cs
@@ -10,6 +10,7 @@ internal sealed class SwitchableCoreManager : ICoreManager, IDisposable, IAsyncD
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
     private ICoreManager _current;
+    private volatile bool _isDisposalRequested;
     private bool _isDisposed;
 
     public SwitchableCoreManager(ICoreManager initial)
@@ -64,6 +65,7 @@ internal sealed class SwitchableCoreManager : ICoreManager, IDisposable, IAsyncD
 
     public async ValueTask DisposeAsync()
     {
+        _isDisposalRequested = true;
         await _gate.WaitAsync().ConfigureAwait(false);
         try
         {
@@ -75,6 +77,33 @@ internal sealed class SwitchableCoreManager : ICoreManager, IDisposable, IAsyncD
             _isDisposed = true;
             Detach(_current);
             DisposeCore(_current);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public bool TryDisposeForShutdown()
+    {
+        _isDisposalRequested = true;
+        // 退出事件不能等待仍在执行的核心操作，Windows 会随 Job 关闭核心。
+        if (!_gate.Wait(0))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (_isDisposed)
+            {
+                return true;
+            }
+
+            _isDisposed = true;
+            Detach(_current);
+            DisposeCore(_current);
+            return true;
         }
         finally
         {
@@ -215,7 +244,7 @@ internal sealed class SwitchableCoreManager : ICoreManager, IDisposable, IAsyncD
 
     private void ThrowIfDisposed()
     {
-        if (_isDisposed)
+        if (_isDisposed || _isDisposalRequested)
         {
             throw new ObjectDisposedException(nameof(SwitchableCoreManager));
         }

--- a/src/Stelliberty.Desktop/Services/SwitchableCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/SwitchableCoreManager.cs
@@ -195,7 +195,7 @@ internal sealed class SwitchableCoreManager : ICoreManager, IDisposable, IAsyncD
         switch (core)
         {
             case IpcCoreManager ipcCoreManager:
-                await ipcCoreManager.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                await ipcCoreManager.EnsureReadyAsync(cancellationToken).ConfigureAwait(false);
                 break;
             case ServiceModeCoreManager serviceModeCoreManager:
                 await serviceModeCoreManager.EnsureReadyAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Stelliberty.Desktop/Views/SubscriptionView.axaml
+++ b/src/Stelliberty.Desktop/Views/SubscriptionView.axaml
@@ -908,11 +908,12 @@
             </controls:DialogPanel>
 
             <controls:DialogPanel PanelWidth="600"
+                                  ContentPadding="0,0,2,0"
                                   AutomationProperties.AutomationId="Subscriptions.ChainProxyDialog"
                                   IsOpen="{Binding ChainProxy.IsDialogVisible}">
               <controls:DialogPanel.DialogContent>
                 <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="14">
-                  <StackPanel Grid.Row="0" Spacing="10">
+                  <StackPanel Grid.Row="0" Spacing="10" Margin="24,24,24,0">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                       <TextBlock Classes="dialog-title" Text="{loc:Loc Subscriptions.Dialog.ChainProxy.Title}" VerticalAlignment="Center" />
                       <Button Grid.Column="1"
@@ -934,7 +935,7 @@
                       <TextBlock Classes="dialog-subtitle" HorizontalAlignment="Center" Text="{loc:Loc Subscriptions.ChainProxy.Loading}" />
                     </StackPanel>
 
-                    <StackPanel MinHeight="160" VerticalAlignment="Center" Spacing="8"
+                    <StackPanel MinHeight="160" Margin="24,0,22,0" VerticalAlignment="Center" Spacing="8"
                                 IsVisible="{Binding ChainProxy.IsErrorVisible}">
                       <TextBlock Classes="dialog-error" TextWrapping="Wrap"
                                  AutomationProperties.AutomationId="Subscriptions.ChainProxy.ErrorText"
@@ -944,9 +945,8 @@
                     <ScrollViewer AutomationProperties.AutomationId="Subscriptions.ChainProxy.ListScroll"
                                   MaxHeight="420"
                                   VerticalScrollBarVisibility="Auto"
-                                  Padding="0,0,2,0"
                                   IsVisible="{Binding ChainProxy.IsListVisible}">
-                      <StackPanel Spacing="12">
+                      <StackPanel Margin="24,0,22,0" Spacing="12">
                         <StackPanel Spacing="8" IsVisible="{Binding ChainProxy.HasBuiltins}">
                           <TextBlock Classes="dialog-section-title" Text="{loc:Loc Subscriptions.ChainProxy.Builtin}" />
                           <ItemsControl AutomationProperties.AutomationId="Subscriptions.ChainProxy.BuiltinList"
@@ -1020,9 +1020,8 @@
                     <ScrollViewer AutomationProperties.AutomationId="Subscriptions.ChainProxy.DraftScroll"
                                   MaxHeight="420"
                                   VerticalScrollBarVisibility="Auto"
-                                  Padding="0,0,2,0"
                                   IsVisible="{Binding ChainProxy.IsDraftVisible}">
-                      <StackPanel Spacing="14">
+                      <StackPanel Margin="24,0,22,0" Spacing="14">
                         <StackPanel Spacing="6">
                           <TextBlock Classes="dialog-label" Text="{loc:Loc Subscriptions.ChainProxy.CustomName}" />
                           <TextBox Classes="dialog-input"
@@ -1090,7 +1089,7 @@
                     </ScrollViewer>
                   </Panel>
 
-                  <Panel Grid.Row="2">
+                  <Panel Grid.Row="2" Margin="24,0,24,24">
                     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right"
                                 IsVisible="{Binding ChainProxy.IsListVisible}">
                       <Button Classes="dialog-secondary"

--- a/src/Stelliberty.Infrastructure/Core/IpcCoreManager.cs
+++ b/src/Stelliberty.Infrastructure/Core/IpcCoreManager.cs
@@ -15,11 +15,11 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
     private CoreSnapshot _last = new(CoreState.Unavailable, null, string.Empty, null);
     private bool _isConnected;
     private bool _isDisposed;
-    // mihomo 重启后会短暂繁忙；重试覆盖连续应用配置。
+    // 核心重启后会短暂繁忙；重试覆盖连续应用配置。
     private const int ApplyConfigMaxAttempts = 20;
     private static readonly TimeSpan ApplyConfigBusyDelay = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(5);
-    private static readonly TimeSpan RestartReadyTimeout = TimeSpan.FromSeconds(12);
+    private static readonly TimeSpan CoreReadyTimeout = TimeSpan.FromSeconds(12);
 
     public event EventHandler<CoreSnapshot>? StateChanged;
 
@@ -40,6 +40,12 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         StateChanged?.Invoke(this, snapshot);
     }
 
+    public async Task EnsureReadyAsync(CancellationToken cancellationToken)
+    {
+        await ConnectAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForReadyAsync(expectedPid: null, "startup", cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<CoreSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
@@ -57,7 +63,13 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         {
             try
             {
-                return await ApplyConfigOnceAsync(request, cancellationToken).ConfigureAwait(false);
+                var result = await ApplyConfigOnceAsync(request, cancellationToken).ConfigureAwait(false);
+                if (result.Mode == CoreApplyMode.Restart)
+                {
+                    await WaitForReadyAsync(result.Pid, "config apply", cancellationToken).ConfigureAwait(false);
+                }
+
+                return result;
             }
             catch (IpcRemoteException exception) when (exception.Code == "core.busy" && attempt < ApplyConfigMaxAttempts)
             {
@@ -98,7 +110,7 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
             ?? throw new InvalidOperationException("Core restart did not return a new process pid.");
         try
         {
-            await WaitForRestartReadyAsync(pid, cancellationToken).ConfigureAwait(false);
+            await WaitForReadyAsync(pid, "restart", cancellationToken).ConfigureAwait(false);
             AppLogger.Info($"Core restart ready: pid={pid} elapsed={stopwatch.Elapsed.TotalMilliseconds:0}ms");
         }
         catch (Exception exception)
@@ -108,20 +120,23 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         }
     }
 
-    private async Task WaitForRestartReadyAsync(int expectedPid, CancellationToken cancellationToken)
+    private async Task WaitForReadyAsync(
+        int? expectedPid,
+        string operation,
+        CancellationToken cancellationToken)
     {
         var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
-        if (IsRestartReady(snapshot, expectedPid))
+        if (IsReady(snapshot, expectedPid))
         {
             return;
         }
 
-        ThrowIfRestartFailed(snapshot);
+        ThrowIfReadyFailed(snapshot, operation);
 
         var completion = new TaskCompletionSource<CoreSnapshot>(TaskCreationOptions.RunContinuationsAsynchronously);
         void OnStateChanged(object? sender, CoreSnapshot state)
         {
-            if (IsRestartReady(state, expectedPid) || state.State == CoreState.Crashed)
+            if (IsReady(state, expectedPid) || state.State == CoreState.Crashed)
             {
                 completion.TrySetResult(state);
             }
@@ -132,28 +147,29 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         {
             // 订阅后立即检查一次，覆盖事件早于响应的竞态。
             snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
-            if (IsRestartReady(snapshot, expectedPid))
+            if (IsReady(snapshot, expectedPid))
             {
                 return;
             }
 
-            ThrowIfRestartFailed(snapshot);
+            ThrowIfReadyFailed(snapshot, operation);
 
-            var timeoutTask = Task.Delay(RestartReadyTimeout, cancellationToken);
+            var timeoutTask = Task.Delay(CoreReadyTimeout, cancellationToken);
             var completed = await Task.WhenAny(completion.Task, timeoutTask).ConfigureAwait(false);
             if (completed == timeoutTask)
             {
                 await timeoutTask.ConfigureAwait(false);
-                throw new TimeoutException($"Core restart timed out: process {expectedPid} did not become running within {RestartReadyTimeout.TotalSeconds:N0} seconds.");
+                var target = expectedPid is null ? "core" : $"process {expectedPid}";
+                throw new TimeoutException($"Core {operation} timed out: {target} did not become running within {CoreReadyTimeout.TotalSeconds:N0} seconds.");
             }
 
             snapshot = await completion.Task.ConfigureAwait(false);
-            if (IsRestartReady(snapshot, expectedPid))
+            if (IsReady(snapshot, expectedPid))
             {
                 return;
             }
 
-            ThrowIfRestartFailed(snapshot);
+            ThrowIfReadyFailed(snapshot, operation);
         }
         finally
         {
@@ -161,12 +177,14 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         }
     }
 
-    private static bool IsRestartReady(CoreSnapshot snapshot, int expectedPid)
+    private static bool IsReady(CoreSnapshot snapshot, int? expectedPid)
     {
-        return snapshot.State == CoreState.Running && snapshot.Pid == expectedPid;
+        return snapshot.State == CoreState.Running
+            && snapshot.Pid is not null
+            && (expectedPid is null || snapshot.Pid == expectedPid);
     }
 
-    private static void ThrowIfRestartFailed(CoreSnapshot snapshot)
+    private static void ThrowIfReadyFailed(CoreSnapshot snapshot, string operation)
     {
         if (snapshot.State != CoreState.Crashed)
         {
@@ -174,8 +192,8 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
         }
 
         var message = string.IsNullOrWhiteSpace(snapshot.LastError)
-            ? "Core entered crashed state after restart."
-            : $"Core entered crashed state after restart: {snapshot.LastError}";
+            ? $"Core entered crashed state during {operation}."
+            : $"Core entered crashed state during {operation}: {snapshot.LastError}";
         throw new InvalidOperationException(message);
     }
 

--- a/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
@@ -29,8 +29,8 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
         _client = client;
     }
 
-    public PipeCoreProxyClient(string mihomoPipe)
-        : this(CreatePipeHttpClient(mihomoPipe))
+    public PipeCoreProxyClient(string corePipe)
+        : this(CreatePipeHttpClient(corePipe))
     {
     }
 
@@ -39,9 +39,9 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
         _client.Dispose();
     }
 
-    public static HttpClient CreatePipeHttpClient(string mihomoPipe)
+    public static HttpClient CreatePipeHttpClient(string corePipe)
     {
-        var pipeName = NormalizeEndpoint(mihomoPipe);
+        var pipeName = NormalizeEndpoint(corePipe);
         var handler = new SocketsHttpHandler
         {
             UseProxy = false,
@@ -71,7 +71,7 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
         {
             if (!Path.IsPathRooted(pipeName))
             {
-                throw new InvalidOperationException("mihomo Unix socket path must be absolute.");
+                throw new InvalidOperationException("Core Unix socket path must be absolute.");
             }
 
             await socket.ConnectAsync(new UnixDomainSocketEndPoint(pipeName), cancellationToken);

--- a/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyDelayTester.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyDelayTester.cs
@@ -22,13 +22,13 @@ public sealed class PipeCoreProxyDelayTester : IProviderProxyDelayTester, IDispo
         _timeoutMilliseconds = timeoutMilliseconds;
     }
 
-    public PipeCoreProxyDelayTester(string mihomoPipe, string testUrl, int timeoutMilliseconds)
-        : this(PipeCoreProxyClient.CreatePipeHttpClient(mihomoPipe), testUrl, timeoutMilliseconds)
+    public PipeCoreProxyDelayTester(string corePipe, string testUrl, int timeoutMilliseconds)
+        : this(PipeCoreProxyClient.CreatePipeHttpClient(corePipe), testUrl, timeoutMilliseconds)
     {
     }
 
-    public PipeCoreProxyDelayTester(string mihomoPipe, Func<string> testUrlFactory, int timeoutMilliseconds)
-        : this(PipeCoreProxyClient.CreatePipeHttpClient(mihomoPipe), testUrlFactory, timeoutMilliseconds)
+    public PipeCoreProxyDelayTester(string corePipe, Func<string> testUrlFactory, int timeoutMilliseconds)
+        : this(PipeCoreProxyClient.CreatePipeHttpClient(corePipe), testUrlFactory, timeoutMilliseconds)
     {
     }
 

--- a/src/Stelliberty.Infrastructure/Subscriptions/PipeCoreProviderClient.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/PipeCoreProviderClient.cs
@@ -12,9 +12,9 @@ public sealed class PipeCoreProviderClient : ISubscriptionProviderSyncer, ISubsc
 {
     private readonly HttpClient _client;
 
-    public PipeCoreProviderClient(string mihomoPipe)
+    public PipeCoreProviderClient(string corePipe)
     {
-        _client = PipeCoreProxyClient.CreatePipeHttpClient(mihomoPipe);
+        _client = PipeCoreProxyClient.CreatePipeHttpClient(corePipe);
         // 同步会让核心重新拉取远程 providers，慢源需要预留余量。
         _client.Timeout = TimeSpan.FromSeconds(30);
     }

--- a/src/Stelliberty.Native/Hub/BootstrapOptions.cs
+++ b/src/Stelliberty.Native/Hub/BootstrapOptions.cs
@@ -2,8 +2,8 @@ namespace Stelliberty.Native.Hub;
 
 public sealed record BootstrapOptions(
     string PipeName,
-    string MihomoPath,
+    string CorePath,
     string DataCoreDir,
     string UserDataDir,
-    string MihomoPipe,
+    string CorePipe,
     string BootstrapYaml);

--- a/src/Stelliberty.Native/Hub/HubBootstrap.cs
+++ b/src/Stelliberty.Native/Hub/HubBootstrap.cs
@@ -19,18 +19,15 @@ public static class HubBootstrap
                 return BootstrapResult.Failure("Hub shutdown has started.");
             }
 
-            if (_started)
-            {
-                return StartCoreLocked();
-            }
+            var isResume = _started;
             try
             {
                 using FfiBootstrapResult ffi = Interop.hub_bootstrap(
                     options.PipeName.Utf8(),
-                    options.MihomoPath.Utf8(),
+                    options.CorePath.Utf8(),
                     options.DataCoreDir.Utf8(),
                     options.UserDataDir.Utf8(),
-                    options.MihomoPipe.Utf8(),
+                    options.CorePipe.Utf8(),
                     options.BootstrapYaml.Utf8());
                 var message = ffi.message.String;
                 if (!ffi.ok.Is)
@@ -39,7 +36,9 @@ public static class HubBootstrap
                     return BootstrapResult.Failure(message);
                 }
                 _started = true;
-                AppLogger.Info($"hub started: {message}");
+                AppLogger.Info(isResume
+                    ? $"Normal-mode core resumed: {message}"
+                    : $"Hub started: {message}");
                 return BootstrapResult.Success(message);
             }
             catch (Exception ex)

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -25,6 +25,8 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
     private readonly Func<bool> _isServiceModeCoreHostActive;
     private readonly Func<CancellationToken, Task<ServiceModeOperationResult>>? _serviceModeSessionActivator;
     private readonly Func<CancellationToken, Task<ServiceModeOperationResult>>? _serviceModeSessionDeactivator;
+    private readonly Action? _serviceModeCoreTransitionStarting;
+    private readonly Func<CancellationToken, Task>? _serviceModeCoreTransitionCompleted;
     private readonly Func<SystemProxyApplicationRequest> _systemProxyRequestFactory;
     private readonly Action<bool>? _tunStateChanged;
 
@@ -101,7 +103,9 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         SystemProxyPlatform systemPlatform = SystemProxyPlatform.Other,
         IClipboardWriter? clipboardWriter = null,
         Func<CancellationToken, Task<ServiceModeOperationResult>>? serviceModeSessionActivator = null,
-        Func<CancellationToken, Task<ServiceModeOperationResult>>? serviceModeSessionDeactivator = null)
+        Func<CancellationToken, Task<ServiceModeOperationResult>>? serviceModeSessionDeactivator = null,
+        Action? serviceModeCoreTransitionStarting = null,
+        Func<CancellationToken, Task>? serviceModeCoreTransitionCompleted = null)
     {
         _localization = localization;
         _systemPlatform = systemPlatform;
@@ -111,6 +115,8 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         _isServiceModeCoreHostActive = isServiceModeCoreHostActive ?? (() => serviceModeManager is not null);
         _serviceModeSessionActivator = serviceModeSessionActivator;
         _serviceModeSessionDeactivator = serviceModeSessionDeactivator;
+        _serviceModeCoreTransitionStarting = serviceModeCoreTransitionStarting;
+        _serviceModeCoreTransitionCompleted = serviceModeCoreTransitionCompleted;
         _systemProxyRequestFactory = systemProxyRequestFactory;
         _tunStateChanged = tunStateChanged;
         _coreRestart = coreRestart;
@@ -638,7 +644,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         Interlocked.Increment(ref _systemProxyApplyVersion);
         if (!_systemProxyApplyLock.Wait(ShutdownProxyLockTimeout))
         {
-            AppLogger.Warning("[Shutdown] System proxy cleanup timed out waiting for the apply lock");
+            AppLogger.Warning("System proxy shutdown cleanup timed out waiting for the apply lock");
             return;
         }
         try
@@ -652,7 +658,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         }
         catch (Exception exception)
         {
-            AppLogger.Warning($"[Shutdown] System proxy cleanup failed: {exception.Message}");
+            AppLogger.Warning($"System proxy shutdown cleanup failed: {exception.Message}");
         }
         finally
         {
@@ -825,8 +831,10 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         ServiceModeOperationResult result;
         var sessionActivationFailed = false;
         var sessionDeactivationFailed = false;
+        var sessionTransitionHandled = false;
         try
         {
+            _serviceModeCoreTransitionStarting?.Invoke();
             result = installOrUpdate
                 ? await _serviceModeManager.InstallOrUpdateAsync(token)
                 : await _serviceModeManager.UninstallAsync(token);
@@ -836,6 +844,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
                 try
                 {
                     var activation = await _serviceModeSessionActivator(token);
+                    sessionTransitionHandled = true;
                     if (activation.IsSuccess)
                     {
                         result = activation;
@@ -865,6 +874,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
                 try
                 {
                     var deactivation = await _serviceModeSessionDeactivator(token);
+                    sessionTransitionHandled = true;
                     sessionDeactivationFailed = !deactivation.IsSuccess;
                     result = deactivation;
                     if (sessionDeactivationFailed)
@@ -929,6 +939,18 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         {
             _isServiceModeBusy = false;
             _lastServiceModeProbe = null;
+            if (!sessionTransitionHandled && _serviceModeCoreTransitionCompleted is not null)
+            {
+                try
+                {
+                    await _serviceModeCoreTransitionCompleted(CancellationToken.None);
+                }
+                catch (Exception exception)
+                {
+                    AppLogger.Warning($"Service mode core transition completion failed: {exception.Message}");
+                }
+            }
+
             try
             {
                 await RefreshServiceModeAsync(token);

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -15,6 +15,8 @@ namespace Stelliberty.Presentation.ViewModels;
 
 public sealed class HomePageViewModel : ViewModelBase, IDisposable
 {
+    // 系统关机不能无限等待正在执行的代理设置。
+    private static readonly TimeSpan ShutdownProxyLockTimeout = TimeSpan.FromSeconds(2);
     private readonly ILocalizationService? _localization;
     private readonly SystemProxyPlatform _systemPlatform;
     private readonly IClipboardWriter? _clipboardWriter;
@@ -634,7 +636,11 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
     {
         // 只关闭本实例的系统代理，保留外部代理状态。
         Interlocked.Increment(ref _systemProxyApplyVersion);
-        _systemProxyApplyLock.Wait();
+        if (!_systemProxyApplyLock.Wait(ShutdownProxyLockTimeout))
+        {
+            AppLogger.Warning("[Shutdown] System proxy cleanup timed out waiting for the apply lock");
+            return;
+        }
         try
         {
             if (!_hasEnabledSystemProxy)
@@ -646,7 +652,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         }
         catch (Exception exception)
         {
-            AppLogger.Warning($"System proxy shutdown cleanup failed: {exception.Message}");
+            AppLogger.Warning($"[Shutdown] System proxy cleanup failed: {exception.Message}");
         }
         finally
         {

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,8 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
         IClipboardWriter? clipboardWriter = null,
         Func<CancellationToken, Task<ServiceModeOperationResult>>? serviceModeSessionActivator = null,
         Func<CancellationToken, Task<ServiceModeOperationResult>>? serviceModeSessionDeactivator = null,
+        Action? serviceModeCoreTransitionStarting = null,
+        Func<CancellationToken, Task>? serviceModeCoreTransitionCompleted = null,
         IAppLogReader? appLogReader = null,
         IAppLogExporter? appLogExporter = null)
     {
@@ -162,7 +164,9 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
             systemPlatform,
             clipboardWriter,
             serviceModeSessionActivator,
-            serviceModeSessionDeactivator);
+            serviceModeSessionDeactivator,
+            serviceModeCoreTransitionStarting,
+            serviceModeCoreTransitionCompleted);
         SystemIntegration = new SettingsSystemIntegrationViewModel(
             _settings,
             settingsStore,

--- a/tests/Stelliberty.ProxySelection.Tests/ProxySelectionBusinessTests.cs
+++ b/tests/Stelliberty.ProxySelection.Tests/ProxySelectionBusinessTests.cs
@@ -1,6 +1,9 @@
 using Stelliberty.Application.Connections;
+using Stelliberty.Application.CoreLogs;
 using Stelliberty.Application.Proxies;
+using Stelliberty.Application.Runtime;
 using Stelliberty.Application.Subscriptions;
+using Stelliberty.Domain.CoreLogs;
 using Stelliberty.Domain.Connections;
 using Stelliberty.Domain.Proxies;
 using Xunit;
@@ -237,6 +240,133 @@ public sealed class ProxySelectionBusinessTests
         Assert.Equal(ConnectionCloseMode.All, core.LastCloseRequest?.Mode);
     }
 
+    [Fact(DisplayName = "Core config apply restores the saved selection before core import resumes")]
+    public async Task CoreConfigApplyRestoresSavedSelectionBeforeCoreImportResumes()
+    {
+        var configProvider = new FakeProxyConfigProvider(TestConfig(
+        [
+            new ProxyGroup("Main", ProxyGroupTypes.Select, "NodeA", ["NodeA", "NodeB"])
+        ]));
+        var coreClient = new FakeProxyCoreClient();
+        var selections = new FakeProxySelectionStore();
+        var subscriptions = new FakeSubscriptionSelectionStore("sub-1");
+        var syncState = new ProxySelectionSyncState();
+        syncState.EnableCoreSelectionImport();
+        selections.SetSelection("sub-1", "Main", "NodeB");
+        var storedProvider = new StoredProxySelectionConfigProvider(
+            configProvider,
+            selections,
+            subscriptions,
+            syncState,
+            importCoreSelections: true);
+        var restorer = new ProxySelectionRestorer(
+            coreClient: coreClient,
+            coreConfigProvider: configProvider,
+            selectedRuntimeConfigProvider: configProvider,
+            selectionProvider: storedProvider,
+            syncState: syncState,
+            subscriptionSelectionStore: subscriptions);
+        var coreManager = new FakeCoreManager
+        {
+            ApplyHandler = request =>
+            {
+                Assert.False(syncState.CanImportCoreSelections);
+                return Task.FromResult(new CoreApplyConfigResult(CoreApplyMode.Restart, 42));
+            }
+        };
+        using var manager = new ProxySelectionRestoringCoreManager(coreManager, restorer);
+
+        await manager.ApplyConfigAsync(new CoreApplyConfigRequest("runtime.yaml", "sub-1"));
+
+        Assert.Contains(coreClient.ChangeRequests, request => request == new ProxyChangeRequest("Main", "NodeB"));
+        Assert.Equal("NodeB", selections.GetSelections("sub-1")["Main"]);
+        Assert.True(syncState.CanImportCoreSelections);
+    }
+
+    [Fact(DisplayName = "Core config apply does not restore another subscription after selection changes")]
+    public async Task CoreConfigApplyDoesNotRestoreAnotherSubscriptionAfterSelectionChanges()
+    {
+        var configProvider = new FakeProxyConfigProvider(TestConfig(
+        [
+            new ProxyGroup("Main", ProxyGroupTypes.Select, "NodeA", ["NodeA", "NodeB"])
+        ]));
+        var coreClient = new FakeProxyCoreClient();
+        var selections = new FakeProxySelectionStore();
+        var subscriptions = new FakeSubscriptionSelectionStore("sub-1");
+        var syncState = new ProxySelectionSyncState();
+        syncState.EnableCoreSelectionImport();
+        selections.SetSelection("sub-1", "Main", "NodeB");
+        var storedProvider = new StoredProxySelectionConfigProvider(
+            configProvider,
+            selections,
+            subscriptions,
+            syncState,
+            importCoreSelections: true);
+        var restorer = new ProxySelectionRestorer(
+            coreClient: coreClient,
+            coreConfigProvider: configProvider,
+            selectedRuntimeConfigProvider: configProvider,
+            selectionProvider: storedProvider,
+            syncState: syncState,
+            subscriptionSelectionStore: subscriptions);
+        var coreManager = new FakeCoreManager
+        {
+            ApplyHandler = request =>
+            {
+                subscriptions.SetCurrentSubscriptionId("sub-2");
+                return Task.FromResult(new CoreApplyConfigResult(CoreApplyMode.Restart, 42));
+            }
+        };
+        using var manager = new ProxySelectionRestoringCoreManager(coreManager, restorer);
+
+        await manager.ApplyConfigAsync(new CoreApplyConfigRequest("runtime.yaml", "sub-1"));
+
+        Assert.Empty(coreClient.ChangeRequests);
+        Assert.Equal("NodeB", selections.GetSelections("sub-1")["Main"]);
+        Assert.False(syncState.CanImportCoreSelections);
+    }
+
+    [Fact(DisplayName = "Failed core config apply keeps saved selections protected while core is unavailable")]
+    public async Task FailedCoreConfigApplyKeepsSavedSelectionsProtectedWhileCoreIsUnavailable()
+    {
+        var configProvider = new FakeProxyConfigProvider(TestConfig(
+        [
+            new ProxyGroup("Main", ProxyGroupTypes.Select, "NodeA", ["NodeA", "NodeB"])
+        ]));
+        var coreClient = new FakeProxyCoreClient();
+        var selections = new FakeProxySelectionStore();
+        var subscriptions = new FakeSubscriptionSelectionStore("sub-1");
+        var syncState = new ProxySelectionSyncState();
+        syncState.EnableCoreSelectionImport();
+        selections.SetSelection("sub-1", "Main", "NodeB");
+        var storedProvider = new StoredProxySelectionConfigProvider(
+            configProvider,
+            selections,
+            subscriptions,
+            syncState,
+            importCoreSelections: true);
+        var restorer = new ProxySelectionRestorer(
+            coreClient: coreClient,
+            coreConfigProvider: configProvider,
+            selectedRuntimeConfigProvider: configProvider,
+            selectionProvider: storedProvider,
+            syncState: syncState,
+            subscriptionSelectionStore: subscriptions);
+        var coreManager = new FakeCoreManager
+        {
+            Snapshot = new CoreSnapshot(CoreState.Crashed, null, string.Empty, "apply failed"),
+            ApplyHandler = _ => throw new InvalidOperationException("apply failed")
+        };
+        using var manager = new ProxySelectionRestoringCoreManager(coreManager, restorer);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            manager.ApplyConfigAsync(new CoreApplyConfigRequest("runtime.yaml", "sub-1")));
+
+        Assert.Empty(coreClient.ChangeRequests);
+        Assert.Equal("NodeB", selections.GetSelections("sub-1")["Main"]);
+        Assert.False(syncState.CanImportCoreSelections);
+    }
+
     [Fact(DisplayName = "Stored provider keeps API-expanded include-all selection")]
     public async Task StoredProviderKeepsApiExpandedIncludeAllSelection()
     {
@@ -399,6 +529,7 @@ public sealed class ProxySelectionBusinessTests
         public bool ChangeResult { get; init; } = true;
         public int CloseConnectionCount { get; private set; }
         public ConnectionCloseRequest? LastCloseRequest { get; private set; }
+        public List<ProxyChangeRequest> ChangeRequests { get; } = [];
 
         public Task<IReadOnlyList<ConnectionInfo>?> GetConnectionsAsync(CancellationToken cancellationToken = default)
         {
@@ -407,6 +538,7 @@ public sealed class ProxySelectionBusinessTests
 
         public Task<bool> ChangeProxyAsync(ProxyChangeRequest request, CancellationToken cancellationToken = default)
         {
+            ChangeRequests.Add(request);
             return Task.FromResult(ChangeResult);
         }
 
@@ -450,6 +582,42 @@ public sealed class ProxySelectionBusinessTests
         public Task<CoreTrafficRate?> GetTrafficAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult<CoreTrafficRate?>(null);
+        }
+    }
+
+    private sealed class FakeCoreManager : ICoreManager
+    {
+        public event EventHandler<CoreSnapshot>? StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<CoreLogMessage>? CoreLogReceived
+        {
+            add { }
+            remove { }
+        }
+
+        public CoreSnapshot Snapshot { get; init; } = new(CoreState.Running, 42, string.Empty, null);
+        public Func<CoreApplyConfigRequest, Task<CoreApplyConfigResult>>? ApplyHandler { get; init; }
+
+        public Task<CoreSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Snapshot);
+        }
+
+        public Task<CoreApplyConfigResult> ApplyConfigAsync(
+            CoreApplyConfigRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return ApplyHandler?.Invoke(request)
+                ?? Task.FromResult(new CoreApplyConfigResult(CoreApplyMode.Reload, Snapshot.Pid ?? 0));
+        }
+
+        public Task RestartAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Promotes v2.0.18 with proxy page performance improvements, bounded core shutdown, runtime state restoration, and updated release metadata. Verified locally with the complete test suite, prebuild, and clean Release build; beta Actions passed on Windows, Linux, and macOS for x64 and arm64.