### PR TITLE
fix(service): expose service upgrades on home

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,11 +1,5 @@
-- Excessive frame-rate drops when switching to the proxy page have been eliminated.
-- Service mode now stops the core correctly when the app exits.
-- The selected subscription and proxy choices now survive app restarts, core restarts, and service mode installation or removal.
-- The chain proxy dialog scrollbar is now aligned correctly.
+- Fixed service mode failing to detect available updates.
 
 ---
 
-- 彻底消除切换到代理页时的帧数过度下降。
-- 服务模式会在应用退出时正确停止核心。
-- 选中的订阅和代理节点现在会在应用重启、核心重启以及服务模式安装或卸载后保持不变。
-- 链式代理对话框的滚动条现已正确对齐。
+- 修复服务模式无法正确检测到新版本的问题。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.18</AppVersion>
+    <AppVersion>2.0.19</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/service/src/installer.rs
+++ b/native/service/src/installer.rs
@@ -569,11 +569,12 @@ fn windows_print_status() -> Result<()> {
         Err(error) => return Err(error).context("Failed to open the Windows service"),
     };
 
-    if service.query_status()?.current_state == ServiceState::Running {
-        println!("running");
+    let state = if service.query_status()?.current_state == ServiceState::Running {
+        "running"
     } else {
-        println!("stopped");
-    }
+        "stopped"
+    };
+    println!("{state} version={}", crate::service_version());
     Ok(())
 }
 
@@ -589,11 +590,12 @@ fn linux_print_status() -> Result<()> {
         .args(["is-active", service_name()])
         .output()
         .context("Failed to query systemd service status")?;
-    if String::from_utf8_lossy(&output.stdout).trim() == "active" {
-        println!("running");
+    let state = if String::from_utf8_lossy(&output.stdout).trim() == "active" {
+        "running"
     } else {
-        println!("stopped");
-    }
+        "stopped"
+    };
+    println!("{state} version={}", crate::service_version());
     Ok(())
 }
 
@@ -609,10 +611,11 @@ fn macos_print_status() -> Result<()> {
         .args(["print", &format!("system/{}", launchd_label())])
         .output()
         .context("Failed to query launchd service status")?;
-    if output.status.success() {
-        println!("running");
+    let state = if output.status.success() {
+        "running"
     } else {
-        println!("stopped");
-    }
+        "stopped"
+    };
+    println!("{state} version={}", crate::service_version());
     Ok(())
 }

--- a/src/Stelliberty.Application/Platform/ServiceModeStatus.cs
+++ b/src/Stelliberty.Application/Platform/ServiceModeStatus.cs
@@ -7,7 +7,8 @@ public sealed record ServiceModeStatus(
     TimeSpan? LastHeartbeatAge = null,
     string? CoreState = null,
     int? CorePid = null,
-    string? CoreLastError = null)
+    string? CoreLastError = null,
+    string? InstalledVersion = null)
 {
     public bool IsInstalled => State is ServiceModeState.Running or ServiceModeState.Stopped;
 

--- a/src/Stelliberty.Application/Updates/AppVersionComparer.cs
+++ b/src/Stelliberty.Application/Updates/AppVersionComparer.cs
@@ -35,6 +35,14 @@ public static class AppVersionComparer
 
     public static string Normalize(string? value) => (value ?? string.Empty).Trim().TrimStart('v', 'V');
 
+    public static bool IsValid(string? value)
+    {
+        var normalized = Normalize(value);
+        var dash = normalized.IndexOf('-', StringComparison.Ordinal);
+        var coreText = dash >= 0 ? normalized[..dash] : normalized;
+        return Version.TryParse(coreText, out _) && (dash < 0 || dash < normalized.Length - 1);
+    }
+
     public static bool IsPreRelease(string? value) => !Parse(value).IsRelease;
 
     private static int ComparePreRelease(string left, string right)

--- a/src/Stelliberty.Desktop/Debug/Commands/Service.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Service.cs
@@ -62,6 +62,8 @@ internal static partial class DebugCommands
             $"state={status.State}",
             $"text={ServiceStatusText(status)}",
             $"message={status.Message}",
+            $"version={status.InstalledVersion ?? "unknown"}",
+            $"update={page.IsServiceModeUpdateAvailable.ToString().ToLowerInvariant()}",
             $"heartbeat={status.LastHeartbeatAge?.TotalSeconds.ToString("0") ?? "none"}",
             $"core={status.CoreState ?? "unknown"}",
             $"pid={status.CorePid?.ToString() ?? "none"}",

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -45,9 +45,9 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         }
 
         var message = result.Message.Trim();
+        var parts = ParseServiceStatus(message);
         if (message.StartsWith("running", StringComparison.OrdinalIgnoreCase))
         {
-            var parts = ParseRunningStatus(message);
             if (parts.ServiceName is not null
                 && !string.Equals(parts.ServiceName, AppRuntimeNames.ServiceName, StringComparison.Ordinal))
             {
@@ -61,12 +61,16 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
                 parts.LastHeartbeatAge,
                 parts.CoreState,
                 parts.CorePid,
-                parts.CoreLastError);
+                parts.CoreLastError,
+                parts.Version);
         }
 
         if (message.StartsWith("stopped", StringComparison.OrdinalIgnoreCase))
         {
-            return new ServiceModeStatus(ServiceModeState.Stopped, "Service is installed but not running.");
+            return new ServiceModeStatus(
+                ServiceModeState.Stopped,
+                "Service is installed but not running.",
+                InstalledVersion: parts.Version);
         }
 
         if (message.StartsWith("not-installed", StringComparison.OrdinalIgnoreCase))
@@ -462,9 +466,10 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
     }
 #endif
 
-    private static (string? ServiceName, TimeSpan? Uptime, TimeSpan? LastHeartbeatAge, string? CoreState, int? CorePid, string? CoreLastError) ParseRunningStatus(string message)
+    private static (string? ServiceName, string? Version, TimeSpan? Uptime, TimeSpan? LastHeartbeatAge, string? CoreState, int? CorePid, string? CoreLastError) ParseServiceStatus(string message)
     {
         string? serviceName = null;
+        string? version = null;
         TimeSpan? uptime = null;
         TimeSpan? lastHeartbeatAge = null;
         string? coreState = null;
@@ -488,6 +493,12 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
             if (part.StartsWith("uptime=", StringComparison.OrdinalIgnoreCase))
             {
                 uptime = ParseSeconds(part["uptime=".Length..]);
+                continue;
+            }
+
+            if (part.StartsWith("version=", StringComparison.OrdinalIgnoreCase))
+            {
+                version = part["version=".Length..];
                 continue;
             }
 
@@ -515,7 +526,7 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
 
         }
 
-        return (serviceName, uptime, lastHeartbeatAge, coreState, corePid, coreLastError);
+        return (serviceName, version, uptime, lastHeartbeatAge, coreState, corePid, coreLastError);
     }
 
     private static TimeSpan? ParseSeconds(string value)

--- a/src/Stelliberty.Infrastructure/Localization/Assets/en.json
+++ b/src/Stelliberty.Infrastructure/Localization/Assets/en.json
@@ -67,6 +67,7 @@
   "Home.VirtualNic.NeedsPrivilege": "Requires administrator or service mode",
   "Home.ServiceMode.Install": "Install Service",
   "Home.ServiceMode.Repair": "Repair Service",
+  "Home.ServiceMode.Update": "Update Service",
   "Home.ServiceMode.Uninstall": "Uninstall Service",
   "Home.ServiceMode.Running": "Service mode running",
   "Home.ServiceMode.Stopped": "Service installed, stopped",

--- a/src/Stelliberty.Infrastructure/Localization/Assets/zh-Hans.json
+++ b/src/Stelliberty.Infrastructure/Localization/Assets/zh-Hans.json
@@ -67,6 +67,7 @@
   "Home.VirtualNic.NeedsPrivilege": "需要管理员或服务模式",
   "Home.ServiceMode.Install": "安装服务模式",
   "Home.ServiceMode.Repair": "修复服务模式",
+  "Home.ServiceMode.Update": "升级服务模式",
   "Home.ServiceMode.Uninstall": "卸载服务模式",
   "Home.ServiceMode.Running": "服务模式运行中",
   "Home.ServiceMode.Stopped": "服务已安装，未运行",

--- a/src/Stelliberty.Infrastructure/Localization/Assets/zh-Hant.json
+++ b/src/Stelliberty.Infrastructure/Localization/Assets/zh-Hant.json
@@ -67,6 +67,7 @@
   "Home.VirtualNic.NeedsPrivilege": "需要管理員或服務模式",
   "Home.ServiceMode.Install": "安裝服務模式",
   "Home.ServiceMode.Repair": "修復服務模式",
+  "Home.ServiceMode.Update": "升級服務模式",
   "Home.ServiceMode.Uninstall": "解除安裝服務模式",
   "Home.ServiceMode.Running": "服務模式執行中",
   "Home.ServiceMode.Stopped": "服務已安裝，未執行",

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -8,6 +8,7 @@ using Stelliberty.Application.Platform;
 using Stelliberty.Application.Proxies;
 using Stelliberty.Domain.Proxies;
 using Stelliberty.Application.Runtime;
+using Stelliberty.Application.Updates;
 using Stelliberty.Presentation.Commands;
 using Stelliberty.Presentation.Formatting;
 
@@ -79,6 +80,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
     private bool _isDisposed;
     private ServiceModeStatus _serviceModeStatus = ServiceModeStatus.Unavailable(string.Empty);
     private DateTimeOffset? _lastServiceModeProbe;
+    private long _serviceModeRefreshVersion;
     private NetworkConnectionType _networkType = NetworkConnectionType.Disconnected;
     private string _networkName = string.Empty;
     private CancellationTokenSource? _refreshCancellation;
@@ -265,9 +267,16 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     public string ServiceModeButtonText => _serviceModeStatus.NeedsRepair
         ? Localize("Home.ServiceMode.Repair")
-        : _serviceModeStatus.IsInstalled
-            ? Localize("Home.ServiceMode.Uninstall")
-            : Localize("Home.ServiceMode.Install");
+        : IsServiceModeUpdateAvailable
+            ? Localize("Home.ServiceMode.Update")
+            : _serviceModeStatus.IsInstalled
+                ? Localize("Home.ServiceMode.Uninstall")
+                : Localize("Home.ServiceMode.Install");
+
+    public bool IsServiceModeUpdateAvailable => _serviceModeStatus.IsInstalled
+        && !string.IsNullOrWhiteSpace(_serviceModeStatus.InstalledVersion)
+        && AppVersionComparer.IsValid(_serviceModeStatus.InstalledVersion)
+        && AppVersionComparer.IsNewer(AppMetadata.Version, _serviceModeStatus.InstalledVersion);
 
     public bool CanToggleServiceMode => !_isServiceModeBusy && _serviceModeManager is not null;
 
@@ -450,7 +459,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     public void RefreshServiceMode(bool force = false)
     {
-        if (_serviceModeManager is null || _refreshCancellation is null || _isRefreshingServiceMode)
+        if (_serviceModeManager is null || _refreshCancellation is null || _isRefreshingServiceMode || _isServiceModeBusy)
         {
             return;
         }
@@ -464,16 +473,18 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         _lastServiceModeProbe = now;
         _isRefreshingServiceMode = true;
         var cancellationToken = _refreshCancellation.Token;
+        var refreshVersion = Interlocked.Increment(ref _serviceModeRefreshVersion);
         _ = Task.Run(async () =>
         {
             try
             {
-                await RefreshServiceModeAsync(cancellationToken);
+                await RefreshServiceModeAsync(refreshVersion, cancellationToken);
             }
             catch (Exception exception)
             {
                 AppLogger.Warning($"Service mode refresh failed: {exception.Message}");
-                if (!cancellationToken.IsCancellationRequested)
+                if (!cancellationToken.IsCancellationRequested
+                    && refreshVersion == Volatile.Read(ref _serviceModeRefreshVersion))
                 {
                     Post(() => ApplyServiceModeStatus(ServiceModeStatus.Unavailable(string.Empty)));
                 }
@@ -485,7 +496,13 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         }, cancellationToken);
     }
 
-    public async Task<ServiceModeStatus> RefreshServiceModeAsync(CancellationToken cancellationToken = default)
+    public Task<ServiceModeStatus> RefreshServiceModeAsync(CancellationToken cancellationToken = default)
+    {
+        var refreshVersion = Interlocked.Increment(ref _serviceModeRefreshVersion);
+        return RefreshServiceModeAsync(refreshVersion, cancellationToken);
+    }
+
+    private async Task<ServiceModeStatus> RefreshServiceModeAsync(long refreshVersion, CancellationToken cancellationToken)
     {
         if (_serviceModeManager is null)
         {
@@ -498,7 +515,8 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
             await _serviceModeManager.SendHeartbeatAsync(cancellationToken);
         }
 
-        if (!cancellationToken.IsCancellationRequested)
+        if (!cancellationToken.IsCancellationRequested
+            && refreshVersion == Volatile.Read(ref _serviceModeRefreshVersion))
         {
             await ApplyServiceModeStatusAsync(status);
         }
@@ -804,7 +822,9 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     private async Task ToggleServiceModeAsync()
     {
-        await ExecuteServiceModeOperationAsync(!_serviceModeStatus.IsInstalled && !_serviceModeStatus.NeedsRepair);
+        var installOrUpdate = !_serviceModeStatus.NeedsRepair
+            && (!_serviceModeStatus.IsInstalled || IsServiceModeUpdateAvailable);
+        await ExecuteServiceModeOperationAsync(installOrUpdate);
     }
 
     public Task<ServiceModeOperationResult> InstallOrUpdateServiceModeAsync(CancellationToken cancellationToken = default)
@@ -1138,6 +1158,7 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(ServiceModeState));
         OnPropertyChanged(nameof(ServiceModeMessage));
         OnPropertyChanged(nameof(ServiceModeButtonText));
+        OnPropertyChanged(nameof(IsServiceModeUpdateAvailable));
         OnPropertyChanged(nameof(CanToggleServiceMode));
         OnPropertyChanged(nameof(IsCoreRunning));
         OnPropertyChanged(nameof(CoreStatusValueText));


### PR DESCRIPTION
- Carry installed service versions through service status and home state
- Offer in-place upgrades for older installed service versions
- Prepare version 2.0.19 and update the changelog

Tested: python scripts/test.py --all