### PR TITLE
chore(release): prepare v2.0.22

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,9 @@
-- Reverted to single-process mode because process separation did not provide clear benefits
-- Fixed some override scripts not taking effect
+- Service-mode core logs now resume correctly after the service recovers
+- Service Mode now detects the bundled service version before offering an update
+- Before or after installing this update, uninstall Service Mode once and then reinstall it
 
 ---
 
-- 回退到单进程模式，目前看起来并没有得到有效反馈
-- 修复某些覆写脚本不生效的问题
+- 服务恢复运行后，服务模式的核心日志现在会正常继续显示
+- 服务模式现在会先检测安装包内的服务版本，再提示更新
+- 安装此次更新前或安装后，请先卸载一次服务模式，再重新安装

--- a/.github/workflows/parallel-trigger.yml
+++ b/.github/workflows/parallel-trigger.yml
@@ -66,7 +66,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if git diff --unified=0 "${BEFORE_SHA}" "${AFTER_SHA}" -- Directory.Build.props | grep -Eq '^[+-].*<AppVersion>'; then
+          if git log --format= --patch "${BEFORE_SHA}..${AFTER_SHA}" -- Directory.Build.props | grep -Eq '^[+-].*<AppVersion>'; then
             echo 'should_build=false' >> "$GITHUB_OUTPUT"
             echo 'Stable version metadata changed in this push; beta build is skipped.'
             exit 0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.21</AppVersion>
+    <AppVersion>2.0.22</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/service/src/lib.rs
+++ b/native/service/src/lib.rs
@@ -103,8 +103,9 @@ fn print_help() {
     );
 }
 
+// 服务版本固定为 crate 版本，不随 App 版本漂移。
 pub(crate) fn service_version() -> &'static str {
-    option_env!("STELLIBERTY_APP_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+    env!("CARGO_PKG_VERSION")
 }
 
 fn parse_log_lines(value: Option<&String>) -> Result<Option<usize>> {

--- a/scripts/build_support/builder.py
+++ b/scripts/build_support/builder.py
@@ -120,7 +120,8 @@ def build_rust(metadata: AppMetadata, configuration: str, target: PlatformTarget
     if configuration == "release":
         command.append("--release")
 
-    env = {"STELLIBERTY_APP_NAME": metadata.app_name, "STELLIBERTY_APP_VERSION": metadata.version}
+    # 服务版本固定为 crate 版本，不随 App 版本漂移。
+    env = {"STELLIBERTY_APP_NAME": metadata.app_name}
     if configuration == "release":
         env.update(release_path_remap_env())
 

--- a/scripts/prebuild.py
+++ b/scripts/prebuild.py
@@ -204,7 +204,6 @@ def build_service_binaries(rid: str, target_dir: Path, configurations: list[str]
             command.append("--release")
         env = os.environ.copy()
         env["STELLIBERTY_APP_NAME"] = metadata.app_name
-        env["STELLIBERTY_APP_VERSION"] = metadata.version
         subprocess.run(command, cwd=ROOT, env=env, check=True)
 
         source = ROOT / "target" / target.rust_target / cargo_profile / target.service_binary

--- a/src/Stelliberty.Application/Platform/ServiceModeStatus.cs
+++ b/src/Stelliberty.Application/Platform/ServiceModeStatus.cs
@@ -8,7 +8,8 @@ public sealed record ServiceModeStatus(
     string? CoreState = null,
     int? CorePid = null,
     string? CoreLastError = null,
-    string? InstalledVersion = null)
+    string? InstalledVersion = null,
+    string? AvailableVersion = null)
 {
     public bool IsInstalled => State is ServiceModeState.Running or ServiceModeState.Stopped;
 

--- a/src/Stelliberty.Desktop/Debug/Commands/Service.cs
+++ b/src/Stelliberty.Desktop/Debug/Commands/Service.cs
@@ -63,6 +63,7 @@ internal static partial class DebugCommands
             $"text={ServiceStatusText(status)}",
             $"message={status.Message}",
             $"version={status.InstalledVersion ?? "unknown"}",
+            $"available={status.AvailableVersion ?? "unknown"}",
             $"update={page.IsServiceModeUpdateAvailable.ToString().ToLowerInvariant()}",
             $"heartbeat={status.LastHeartbeatAge?.TotalSeconds.ToString("0") ?? "none"}",
             $"core={status.CoreState ?? "unknown"}",

--- a/src/Stelliberty.Desktop/Services/CorePipeLogStreamer.cs
+++ b/src/Stelliberty.Desktop/Services/CorePipeLogStreamer.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Security.Cryptography;
@@ -19,6 +20,7 @@ internal sealed class CorePipeLogStreamer : IDisposable
     private readonly object _gate = new();
     private CancellationTokenSource? _streamCancellation;
     private Task? _streamTask;
+    private long _streamGeneration;
     private bool _isDisposed;
 
     public CorePipeLogStreamer(string corePipe)
@@ -28,8 +30,26 @@ internal sealed class CorePipeLogStreamer : IDisposable
 
     public event EventHandler<CoreLogMessage>? MessageReceived;
 
+    public void Start()
+    {
+        long generation;
+        lock (_gate)
+        {
+            if (_isDisposed || _streamCancellation is not null)
+            {
+                return;
+            }
+
+            generation = StartLocked();
+        }
+
+        AppLogger.Info($"Service-mode core log stream started: generation={generation}");
+    }
+
     public void Restart()
     {
+        long generation;
+        var replacedActiveStream = false;
         lock (_gate)
         {
             if (_isDisposed)
@@ -37,22 +57,30 @@ internal sealed class CorePipeLogStreamer : IDisposable
                 return;
             }
 
-            StopLocked();
-            _streamCancellation = new CancellationTokenSource();
-            _streamTask = Task.Run(() => RunAsync(_streamCancellation.Token));
+            replacedActiveStream = StopLocked() is not null;
+            generation = StartLocked();
         }
+
+        AppLogger.Info($"Service-mode core log stream restarted: generation={generation} replacedActive={replacedActiveStream.ToString().ToLowerInvariant()}");
     }
 
     public void Stop()
     {
+        long? generation;
         lock (_gate)
         {
-            StopLocked();
+            generation = StopLocked();
+        }
+
+        if (generation is not null)
+        {
+            AppLogger.Info($"Service-mode core log stream stopped: generation={generation}");
         }
     }
 
     public void Dispose()
     {
+        long? generation;
         lock (_gate)
         {
             if (_isDisposed)
@@ -61,13 +89,26 @@ internal sealed class CorePipeLogStreamer : IDisposable
             }
 
             _isDisposed = true;
-            StopLocked();
+            generation = StopLocked();
         }
 
         MessageReceived = null;
+        if (generation is not null)
+        {
+            AppLogger.Info($"Service-mode core log stream disposed: generation={generation}");
+        }
     }
 
-    private void StopLocked()
+    private long StartLocked()
+    {
+        var generation = ++_streamGeneration;
+        var cancellation = new CancellationTokenSource();
+        _streamCancellation = cancellation;
+        _streamTask = Task.Run(() => RunAsync(generation, cancellation.Token));
+        return generation;
+    }
+
+    private long? StopLocked()
     {
         var cancellation = _streamCancellation;
         var task = _streamTask;
@@ -75,11 +116,12 @@ internal sealed class CorePipeLogStreamer : IDisposable
         _streamTask = null;
         if (cancellation is null)
         {
-            return;
+            return null;
         }
 
         cancellation.Cancel();
         DisposeCancellationAfterTask(cancellation, task);
+        return _streamGeneration;
     }
 
     private static void DisposeCancellationAfterTask(CancellationTokenSource cancellation, Task? task)
@@ -97,13 +139,25 @@ internal sealed class CorePipeLogStreamer : IDisposable
             TaskScheduler.Default);
     }
 
-    private async Task RunAsync(CancellationToken cancellationToken)
+    private async Task RunAsync(long generation, CancellationToken cancellationToken)
     {
+        var attempt = 0;
         while (!cancellationToken.IsCancellationRequested)
         {
+            attempt++;
             try
             {
-                await StreamOnceAsync(cancellationToken).ConfigureAwait(false);
+                var ended = await StreamOnceAsync(generation, attempt, cancellationToken).ConfigureAwait(false);
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (ShouldLogAttempt(attempt))
+                {
+                    AppLogger.Warning(
+                        $"Service-mode core log stream disconnected: generation={generation} attempt={attempt} reason={ended.Reason} payloads={ended.PayloadCount} messages={ended.MessageCount} elapsed={ended.Elapsed.TotalMilliseconds:0}ms retry={ReconnectDelay.TotalSeconds:0}s");
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -111,30 +165,44 @@ internal sealed class CorePipeLogStreamer : IDisposable
             }
             catch (Exception exception)
             {
-                AppLogger.Warning($"Service-mode core log stream was interrupted: {exception.Message}");
+                if (ShouldLogAttempt(attempt))
+                {
+                    AppLogger.Warning(
+                        $"Service-mode core log stream interrupted: generation={generation} attempt={attempt} error={exception.GetType().Name} message={exception.Message} retry={ReconnectDelay.TotalSeconds:0}s");
+                }
             }
 
             await Task.Delay(ReconnectDelay, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private async Task StreamOnceAsync(CancellationToken cancellationToken)
+    private async Task<StreamEnd> StreamOnceAsync(long generation, int attempt, CancellationToken cancellationToken)
     {
+        var startedAt = Stopwatch.GetTimestamp();
         await using var stream = await ConnectStreamAsync(_pipeName, cancellationToken).ConfigureAwait(false);
         await WriteHandshakeAsync(stream, cancellationToken).ConfigureAwait(false);
         await ReadHandshakeAsync(stream, cancellationToken).ConfigureAwait(false);
+        if (ShouldLogAttempt(attempt))
+        {
+            AppLogger.Info($"Service-mode core log stream connected: generation={generation} attempt={attempt}");
+        }
+
+        List<byte>? fragmentedPayload = null;
+        var payloadCount = 0;
+        var messageCount = 0;
+        var hasLoggedFirstPayload = false;
 
         while (!cancellationToken.IsCancellationRequested)
         {
             var frame = await ReadFrameAsync(stream, cancellationToken).ConfigureAwait(false);
             if (frame is null)
             {
-                return;
+                return new StreamEnd("end-of-stream", payloadCount, messageCount, Stopwatch.GetElapsedTime(startedAt));
             }
 
             if (frame.Value.Opcode == 0x8)
             {
-                return;
+                return new StreamEnd("close-frame", payloadCount, messageCount, Stopwatch.GetElapsedTime(startedAt));
             }
 
             if (frame.Value.Opcode == 0x9)
@@ -145,10 +213,79 @@ internal sealed class CorePipeLogStreamer : IDisposable
 
             if (frame.Value.Opcode is 0x1 or 0x2)
             {
-                Publish(Encoding.UTF8.GetString(frame.Value.Payload));
+                if (fragmentedPayload is not null)
+                {
+                    throw new IOException("Log WebSocket started a new message before the fragmented message ended");
+                }
+
+                if (frame.Value.IsFinal)
+                {
+                    payloadCount++;
+                    var parsed = Publish(Encoding.UTF8.GetString(frame.Value.Payload));
+                    messageCount += parsed;
+                    LogFirstPayload(generation, attempt, frame.Value.Payload.Length, parsed, fragmented: false, ref hasLoggedFirstPayload);
+                    continue;
+                }
+
+                fragmentedPayload = new List<byte>(frame.Value.Payload.Length);
+                AppendFragment(fragmentedPayload, frame.Value.Payload);
+                continue;
+            }
+
+            if (frame.Value.Opcode == 0x0)
+            {
+                if (fragmentedPayload is null)
+                {
+                    throw new IOException("Log WebSocket continuation frame has no initial frame");
+                }
+
+                AppendFragment(fragmentedPayload, frame.Value.Payload);
+                if (!frame.Value.IsFinal)
+                {
+                    continue;
+                }
+
+                payloadCount++;
+                var payload = fragmentedPayload.ToArray();
+                fragmentedPayload = null;
+                var parsed = Publish(Encoding.UTF8.GetString(payload));
+                messageCount += parsed;
+                LogFirstPayload(generation, attempt, payload.Length, parsed, fragmented: true, ref hasLoggedFirstPayload);
             }
         }
+
+        return new StreamEnd("canceled", payloadCount, messageCount, Stopwatch.GetElapsedTime(startedAt));
     }
+
+    private static void AppendFragment(List<byte> buffer, byte[] payload)
+    {
+        if (buffer.Count > MaxFrameBytes - payload.Length)
+        {
+            throw new IOException("Log WebSocket fragmented message is too large");
+        }
+
+        buffer.AddRange(payload);
+    }
+
+    private static void LogFirstPayload(
+        long generation,
+        int attempt,
+        int byteCount,
+        int messageCount,
+        bool fragmented,
+        ref bool hasLoggedFirstPayload)
+    {
+        if (hasLoggedFirstPayload)
+        {
+            return;
+        }
+
+        hasLoggedFirstPayload = true;
+        AppLogger.Info(
+            $"Service-mode core log stream received first payload: generation={generation} attempt={attempt} bytes={byteCount} messages={messageCount} fragmented={fragmented.ToString().ToLowerInvariant()}");
+    }
+
+    private static bool ShouldLogAttempt(int attempt) => attempt <= 5 || attempt % 30 == 0;
 
     private static async Task WriteHandshakeAsync(Stream stream, CancellationToken cancellationToken)
     {
@@ -207,6 +344,7 @@ internal sealed class CorePipeLogStreamer : IDisposable
             return null;
         }
 
+        var isFinal = (header[0] & 0x80) != 0;
         var opcode = header[0] & 0x0F;
         var isMasked = (header[1] & 0x80) != 0;
         var length = header[1] & 0x7F;
@@ -251,7 +389,7 @@ internal sealed class CorePipeLogStreamer : IDisposable
             }
         }
 
-        return new WebSocketFrame(opcode, payload);
+        return new WebSocketFrame(isFinal, opcode, payload);
     }
 
     private static async Task WriteClientFrameAsync(Stream stream, int opcode, byte[] payload, CancellationToken cancellationToken)
@@ -299,17 +437,20 @@ internal sealed class CorePipeLogStreamer : IDisposable
         }
     }
 
-    private void Publish(string line)
+    private int Publish(string line)
     {
         if (_isDisposed)
         {
-            return;
+            return 0;
         }
 
-        foreach (var message in _parser.Parse(line))
+        var messages = _parser.Parse(line);
+        foreach (var message in messages)
         {
             MessageReceived?.Invoke(this, message);
         }
+
+        return messages.Count;
     }
 
     private static async Task<Stream> ConnectStreamAsync(string pipeName, CancellationToken cancellationToken)
@@ -350,5 +491,7 @@ internal sealed class CorePipeLogStreamer : IDisposable
         return pipePath.StartsWith(prefix, StringComparison.Ordinal) ? pipePath[prefix.Length..] : pipePath;
     }
 
-    private readonly record struct WebSocketFrame(int Opcode, byte[] Payload);
+    private readonly record struct WebSocketFrame(bool IsFinal, int Opcode, byte[] Payload);
+
+    private readonly record struct StreamEnd(string Reason, int PayloadCount, int MessageCount, TimeSpan Elapsed);
 }

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -18,6 +18,11 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
     private static readonly TimeSpan StatusSettleTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan StatusPollInterval = TimeSpan.FromMilliseconds(250);
     private const string PrivilegeCanceledMessage = "Administrator approval was canceled; no changes were made.";
+    // 安装包替换服务文件后按文件特征失效缓存，避免每次状态刷新重复启动进程。
+    private readonly object _serviceVersionCacheLock = new();
+    private DateTime _serviceVersionFileLastWriteUtc;
+    private long _serviceVersionFileLength = -1;
+    private string? _cachedServiceVersion;
 
     public async Task<ServiceModeStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
@@ -46,6 +51,11 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
 
         var message = result.Message.Trim();
         var parts = ParseServiceStatus(message);
+        var isInstalledState = message.StartsWith("running", StringComparison.OrdinalIgnoreCase)
+            || message.StartsWith("stopped", StringComparison.OrdinalIgnoreCase);
+        var availableVersion = isInstalledState
+            ? await GetAvailableServiceVersionAsync(cancellationToken).ConfigureAwait(false)
+            : null;
         if (message.StartsWith("running", StringComparison.OrdinalIgnoreCase))
         {
             if (parts.ServiceName is not null
@@ -62,7 +72,8 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
                 parts.CoreState,
                 parts.CorePid,
                 parts.CoreLastError,
-                parts.Version);
+                parts.Version,
+                availableVersion);
         }
 
         if (message.StartsWith("stopped", StringComparison.OrdinalIgnoreCase))
@@ -70,7 +81,8 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
             return new ServiceModeStatus(
                 ServiceModeState.Stopped,
                 "Service is installed but not running.",
-                InstalledVersion: parts.Version);
+                InstalledVersion: parts.Version,
+                AvailableVersion: availableVersion);
         }
 
         if (message.StartsWith("not-installed", StringComparison.OrdinalIgnoreCase))
@@ -297,6 +309,52 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         return File.Exists(DesktopApplicationLayout.ServiceInstalledBinaryPath)
             ? DesktopApplicationLayout.ServiceInstalledBinaryPath
             : null;
+    }
+
+    private async Task<string?> GetAvailableServiceVersionAsync(CancellationToken cancellationToken)
+    {
+        var path = DesktopApplicationLayout.ServiceCommandBinaryPath;
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        var fileInfo = new FileInfo(path);
+        var lastWriteUtc = fileInfo.LastWriteTimeUtc;
+        var length = fileInfo.Length;
+        lock (_serviceVersionCacheLock)
+        {
+            if (_serviceVersionFileLength == length
+                && _serviceVersionFileLastWriteUtc == lastWriteUtc)
+            {
+                return _cachedServiceVersion;
+            }
+        }
+
+        var result = await RunServiceCommandAsync(
+            "version",
+            false,
+            StatusTimeout,
+            cancellationToken,
+            binaryPath: path).ConfigureAwait(false);
+        var version = result.IsSuccess ? ParseServiceVersion(result.Message) : null;
+        if (version is not null)
+        {
+            lock (_serviceVersionCacheLock)
+            {
+                _serviceVersionFileLastWriteUtc = lastWriteUtc;
+                _serviceVersionFileLength = length;
+                _cachedServiceVersion = version;
+            }
+        }
+
+        return version;
+    }
+
+    private static string? ParseServiceVersion(string message)
+    {
+        var parts = message.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 ? parts[^1] : null;
     }
 
     private static ServiceModeStatus? DetectServiceRepairStatus()

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -256,7 +256,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
 
     private static void LogStateTransition(CoreSnapshot? previous, CoreSnapshot snapshot)
     {
-        var previousState = previous?.State.ToString() ?? "None";
+        var previousState = previous?.State.ToString() ?? "none";
         var pid = snapshot.Pid?.ToString() ?? "none";
         var error = string.IsNullOrWhiteSpace(snapshot.LastError) ? "none" : snapshot.LastError;
         var message = $"Service-mode core state changed: previous={previousState} current={snapshot.State} pid={pid} error={error}";

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -233,18 +233,41 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
             return;
         }
 
-        if (snapshot.State != CoreState.Running)
+        if (snapshot.State == CoreState.Running)
+        {
+            // 状态查询恢复后必须重新建立先前停止的日志流。
+            _logStreamer.Start();
+        }
+        else
         {
             _logStreamer.Stop();
         }
+
         _setCoreHostActive(snapshot.State == CoreState.Running);
         if (_lastSnapshot == snapshot)
         {
             return;
         }
 
+        LogStateTransition(_lastSnapshot, snapshot);
         _lastSnapshot = snapshot;
         StateChanged?.Invoke(this, snapshot);
+    }
+
+    private static void LogStateTransition(CoreSnapshot? previous, CoreSnapshot snapshot)
+    {
+        var previousState = previous?.State.ToString() ?? "None";
+        var pid = snapshot.Pid?.ToString() ?? "none";
+        var error = string.IsNullOrWhiteSpace(snapshot.LastError) ? "none" : snapshot.LastError;
+        var message = $"Service-mode core state changed: previous={previousState} current={snapshot.State} pid={pid} error={error}";
+
+        if (snapshot.State is CoreState.Unavailable or CoreState.Crashed)
+        {
+            AppLogger.Warning(message);
+            return;
+        }
+
+        AppLogger.Info(message);
     }
 
     private async Task<string?> ProbeVersionAsync(CancellationToken cancellationToken)

--- a/src/Stelliberty.Desktop/Stelliberty.Desktop.csproj
+++ b/src/Stelliberty.Desktop/Stelliberty.Desktop.csproj
@@ -40,11 +40,6 @@
     <AvaloniaResource Include="Assets\fonts\**" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == ''">
-    <AvaloniaResource Include="Assets\win\**" />
-    <AvaloniaResource Include="Assets\linux\**" />
-    <AvaloniaResource Include="Assets\macos\**" />
-  </ItemGroup>
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">
     <AvaloniaResource Include="Assets\win\**" />
   </ItemGroup>

--- a/src/Stelliberty.Desktop/Views/LocalFilePicker.cs
+++ b/src/Stelliberty.Desktop/Views/LocalFilePicker.cs
@@ -18,13 +18,13 @@ internal static class LocalFilePicker
         {
             // StorageProvider 必须绑定当前 TopLevel，不能脱离窗口调用。
             var provider = topLevel.StorageProvider;
-            AppLogger.Info($"File picker preparing to open: TopLevel={topLevel.GetType().Name}, Provider={provider.GetType().FullName}, CanOpen={provider.CanOpen}");
+            AppLogger.Info($"File picker preparing to open: topLevel={topLevel.GetType().Name} provider={provider.GetType().FullName} canOpen={provider.CanOpen}");
             if (!provider.CanOpen)
             {
                 throw new InvalidOperationException("File picker is unavailable");
             }
 
-            AppLogger.Info($"File picker call started: Title={title}, Filter={filterName}");
+            AppLogger.Info($"File picker call started: title={title} filter={filterName}");
             var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = title,
@@ -36,7 +36,7 @@ internal static class LocalFilePicker
                 ]
             });
 
-            AppLogger.Info($"File picker call completed: Count={files.Count}");
+            AppLogger.Info($"File picker call completed: count={files.Count}");
             return files.Count > 0 ? files[0].TryGetLocalPath() : null;
         }
         catch (Exception)
@@ -57,7 +57,7 @@ internal static class LocalFilePicker
         try
         {
             var provider = topLevel.StorageProvider;
-            AppLogger.Info($"Save file picker preparing to open: TopLevel={topLevel.GetType().Name}, Provider={provider.GetType().FullName}, CanSave={provider.CanSave}");
+            AppLogger.Info($"Save file picker preparing to open: topLevel={topLevel.GetType().Name} provider={provider.GetType().FullName} canSave={provider.CanSave}");
             if (!provider.CanSave)
             {
                 throw new InvalidOperationException("Save file picker is unavailable");

--- a/src/Stelliberty.Infrastructure/DataManagement/FileDataBackupService.cs
+++ b/src/Stelliberty.Infrastructure/DataManagement/FileDataBackupService.cs
@@ -216,7 +216,7 @@ public sealed class FileDataBackupService(string appDataDirectory) : IDataManage
                 added++;
             }
 
-            AppLogger.Info($"Data backup merge restored: {backupPath}, added={added}, skipped={skipped}");
+            AppLogger.Info($"Data backup merge restored: {backupPath} added={added} skipped={skipped}");
             return (added, skipped);
         }
 
@@ -245,7 +245,7 @@ public sealed class FileDataBackupService(string appDataDirectory) : IDataManage
         }
 
         RestoreLocalSettings(currentLocalSettings);
-        AppLogger.Info($"Data backup overwrite restored: {backupPath}, restored={restored}");
+        AppLogger.Info($"Data backup overwrite restored: {backupPath} restored={restored}");
         return (restored, 0);
     }
 

--- a/src/Stelliberty.Infrastructure/Updates/GitHubAppUpdateChecker.cs
+++ b/src/Stelliberty.Infrastructure/Updates/GitHubAppUpdateChecker.cs
@@ -69,7 +69,7 @@ public sealed class GitHubAppUpdateChecker : IAppUpdateChecker
             catch (HttpRequestException exception)
             {
                 lastFailure = exception;
-                AppLogger.Warning($"App update check route failed: route={route.Name}; error={exception.Message}");
+                AppLogger.Warning($"App update check route failed: route={route.Name} error={exception.Message}");
             }
             catch (Exception exception)
             {

--- a/src/Stelliberty.Native/Hub/HubBootstrap.cs
+++ b/src/Stelliberty.Native/Hub/HubBootstrap.cs
@@ -32,7 +32,7 @@ public static class HubBootstrap
                 var message = ffi.message.String;
                 if (!ffi.ok.Is)
                 {
-                    AppLogger.Error($"hub startup failed: {message}");
+                    AppLogger.Error($"Hub startup failed: {message}");
                     return BootstrapResult.Failure(message);
                 }
                 _started = true;
@@ -43,7 +43,7 @@ public static class HubBootstrap
             }
             catch (Exception ex)
             {
-                AppLogger.Error(ex, "hub startup exception");
+                AppLogger.Error(ex, "Hub startup exception");
                 return BootstrapResult.Failure(ex.Message);
             }
         }
@@ -111,7 +111,7 @@ public static class HubBootstrap
             }
             catch (Exception ex)
             {
-                AppLogger.Warning($"hub shutdown exception ignored: {ex.Message}");
+                AppLogger.Warning($"Hub shutdown exception ignored: {ex.Message}");
             }
             finally
             {

--- a/src/Stelliberty.Presentation/ViewModels/CoreLogs/CoreLogPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/CoreLogs/CoreLogPageViewModel.cs
@@ -95,7 +95,7 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
             var isActive = !string.IsNullOrWhiteSpace(value);
             if (wasActive != isActive)
             {
-                AppLogger.Info($"Core log search changed: active={isActive.ToString().ToLowerInvariant()} total={_state.Logs.Count}");
+                AppLogger.Info($"Core log search changed: active={isActive.ToString().ToLowerInvariant()} count={_state.Logs.Count}");
             }
 
             RaiseLogStateChanged();
@@ -118,14 +118,14 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
         }
 
         _state = _state with { FilterLevel = level };
-        AppLogger.Info($"Core log filter changed: level={level?.ToString() ?? "All"} total={_state.Logs.Count}");
+        AppLogger.Info($"Core log filter changed: level={level?.ToString() ?? "All"} count={_state.Logs.Count}");
         RaiseLogStateChanged();
     }
 
     public void TogglePause()
     {
         _state = _reducer.TogglePause(_state);
-        AppLogger.Info($"Core log monitoring changed: paused={_state.IsMonitoringPaused.ToString().ToLowerInvariant()} total={_state.Logs.Count}");
+        AppLogger.Info($"Core log monitoring changed: paused={_state.IsMonitoringPaused.ToString().ToLowerInvariant()} count={_state.Logs.Count}");
         RaiseLogStateChanged();
     }
 
@@ -138,7 +138,7 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
             var filter = _state.FilterLevel?.ToString() ?? "All";
             var searchActive = !string.IsNullOrWhiteSpace(_state.SearchKeyword);
             AppLogger.Info(
-                $"Core log page received first batch: received={logs.Count} stored={_state.Logs.Count} filter={filter} searchActive={searchActive.ToString().ToLowerInvariant()}");
+                $"Core log page received first batch: received={logs.Count} count={_state.Logs.Count} filter={filter} searchActive={searchActive.ToString().ToLowerInvariant()}");
         }
 
         RaiseLogStateChanged();

--- a/src/Stelliberty.Presentation/ViewModels/CoreLogs/CoreLogPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/CoreLogs/CoreLogPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using Stelliberty.Application.CoreLogs;
+using Stelliberty.Application.Diagnostics;
 using Stelliberty.Domain.CoreLogs;
 using Stelliberty.Application.Localization;
 using Stelliberty.Presentation.Commands;
@@ -89,7 +90,14 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
                 return;
             }
 
+            var wasActive = !string.IsNullOrWhiteSpace(_state.SearchKeyword);
             _state = _state with { SearchKeyword = value };
+            var isActive = !string.IsNullOrWhiteSpace(value);
+            if (wasActive != isActive)
+            {
+                AppLogger.Info($"Core log search changed: active={isActive.ToString().ToLowerInvariant()} total={_state.Logs.Count}");
+            }
+
             RaiseLogStateChanged();
         }
     }
@@ -110,24 +118,37 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
         }
 
         _state = _state with { FilterLevel = level };
+        AppLogger.Info($"Core log filter changed: level={level?.ToString() ?? "All"} total={_state.Logs.Count}");
         RaiseLogStateChanged();
     }
 
     public void TogglePause()
     {
         _state = _reducer.TogglePause(_state);
+        AppLogger.Info($"Core log monitoring changed: paused={_state.IsMonitoringPaused.ToString().ToLowerInvariant()} total={_state.Logs.Count}");
         RaiseLogStateChanged();
     }
 
     public void AppendLogs(IReadOnlyList<CoreLogMessage> logs)
     {
+        var previousCount = _state.Logs.Count;
         _state = _reducer.Append(_state, logs);
+        if (previousCount == 0 && _state.Logs.Count > 0)
+        {
+            var filter = _state.FilterLevel?.ToString() ?? "All";
+            var searchActive = !string.IsNullOrWhiteSpace(_state.SearchKeyword);
+            AppLogger.Info(
+                $"Core log page received first batch: received={logs.Count} stored={_state.Logs.Count} filter={filter} searchActive={searchActive.ToString().ToLowerInvariant()}");
+        }
+
         RaiseLogStateChanged();
     }
 
     public void ClearLogs()
     {
+        var clearedCount = _state.Logs.Count;
         _state = _reducer.Clear(_state);
+        AppLogger.Info($"Core logs cleared: count={clearedCount}");
         LogsCleared?.Invoke(this, EventArgs.Empty);
         RaiseLogStateChanged();
     }
@@ -142,6 +163,7 @@ public sealed class CoreLogPageViewModel : ViewModelBase, IDisposable
         _isCoreRunning = isRunning;
         if (!isRunning)
         {
+            AppLogger.Info($"Core log page reset because core is not running: count={_state.Logs.Count}");
             _state = CoreLogState.Initial;
         }
 

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -275,8 +275,10 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     public bool IsServiceModeUpdateAvailable => _serviceModeStatus.IsInstalled
         && !string.IsNullOrWhiteSpace(_serviceModeStatus.InstalledVersion)
+        && !string.IsNullOrWhiteSpace(_serviceModeStatus.AvailableVersion)
         && AppVersionComparer.IsValid(_serviceModeStatus.InstalledVersion)
-        && AppVersionComparer.IsNewer(AppMetadata.Version, _serviceModeStatus.InstalledVersion);
+        && AppVersionComparer.IsValid(_serviceModeStatus.AvailableVersion)
+        && AppVersionComparer.IsNewer(_serviceModeStatus.AvailableVersion, _serviceModeStatus.InstalledVersion);
 
     public bool CanToggleServiceMode => !_isServiceModeBusy && _serviceModeManager is not null;
 

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
@@ -678,7 +678,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
                 SubscriptionAutoDelay.Reset();
                 ProxyPage.CancelDelayTests();
                 await ApplyEmptyRuntimeToCoreAsync();
-                AppLogger.Info("Runtime config refreshed after data overwrite restore：empty");
+                AppLogger.Info("Runtime config refreshed after data overwrite restore: empty");
                 return;
             }
 
@@ -755,7 +755,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
         if (string.IsNullOrWhiteSpace(subscriptionId))
         {
             await ApplyEmptyRuntimeToCoreAsync(refreshVersion, endpointChangeVersion);
-            AppLogger.Info($"{successMessage}：empty");
+            AppLogger.Info($"{successMessage}: empty");
             return;
         }
 
@@ -803,13 +803,13 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
                 SubscriptionPage.ClearSubscriptionRuntimeFailure(subscriptionId);
             }
 
-            AppLogger.Info($"{successMessage}：{subscriptionId}");
+            AppLogger.Info($"{successMessage}: {subscriptionId}");
         }
         catch (Exception exception)
         {
             LastRuntimeApplyMode = "error";
             LastRuntimeApplyError = exception.Message;
-            AppLogger.Error(exception, $"{failureMessage}：{subscriptionId}");
+            AppLogger.Error(exception, $"{failureMessage}: {subscriptionId}");
             // 生成器负责覆写禁用和重试；此路径只回退到空配置。
             try
             {


### PR DESCRIPTION
- 恢复服务模式核心日志流，并改进服务恢复后的日志续接
- 修复安装包内服务版本识别与更新提示
- 提醒用户安装更新前或安装后卸载并重新安装一次服务模式
- 版本号更新到 2.0.22

测试：python scripts/test.py --all；config-switch 首轮失败后单独复跑通过