### PR TITLE
promote: beta to stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,7 @@
 - Fixed proxy and subscription selections being lost after an abrupt exit, which previously reset the selected nodes and current subscription without warning
 - Fixed delay testing a node cancelling tests already running on other nodes, so each node now keeps its own result
 - Deleting a subscription now also clears the proxy selections it left behind
-- Traffic curves on the home page now scroll and morph smoothly in real time
+- Traffic curves on the home page now scroll smoothly, without the small jump that appeared every second
 - Removed the end point dot from the traffic curves
 - Hovering the tray icon now shows the app name
 
@@ -10,6 +10,6 @@
 - 修复了异常退出后代理和订阅选择丢失的问题，该问题曾导致已选节点和当前订阅被无声重置
 - 修复了测试某个节点延迟会取消其它节点正在进行的测试的问题，现在每个节点都能保留自己的结果
 - 删除订阅时现在会同时清理它遗留的代理选择记录
-- 首页流量曲线现在会实时平滑滚动与过渡
+- 首页流量曲线现在会平滑滚动，不再每秒轻微跳动一下
 - 移除了流量曲线末端的圆点
 - 悬停托盘图标现在会显示应用名称

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,15 @@
-- Fixed an issue with subscription updates that previously caused the selected subscription to be cleared and replaced with an empty config when a chain hop or custom rule outbound no longer existed
-- Improved dialog error alignment, which now matches the text above it
+- Fixed proxy and subscription selections being lost after an abrupt exit, which previously reset the selected nodes and current subscription without warning
+- Fixed delay testing a node cancelling tests already running on other nodes, so each node now keeps its own result
+- Deleting a subscription now also clears the proxy selections it left behind
+- Traffic curves on the home page now scroll and morph smoothly in real time
+- Removed the end point dot from the traffic curves
+- Hovering the tray icon now shows the app name
 
 ---
 
-- 修复了关于订阅更新的错误，该问题曾导致链式跳点或自定义规则出站目标不存在时清空当前订阅并切回空配置
-- 对对话框错误提示的对齐进行了改善，这使得错误文字与上方内容对齐
+- 修复了异常退出后代理和订阅选择丢失的问题，该问题曾导致已选节点和当前订阅被无声重置
+- 修复了测试某个节点延迟会取消其它节点正在进行的测试的问题，现在每个节点都能保留自己的结果
+- 删除订阅时现在会同时清理它遗留的代理选择记录
+- 首页流量曲线现在会实时平滑滚动与过渡
+- 移除了流量曲线末端的圆点
+- 悬停托盘图标现在会显示应用名称

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.27</AppVersion>
+    <AppVersion>2.0.28</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.26</AppVersion>
+    <AppVersion>2.0.27</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/src/Stelliberty.Application/Proxies/IProxySelectionStore.cs
+++ b/src/Stelliberty.Application/Proxies/IProxySelectionStore.cs
@@ -7,4 +7,7 @@ public interface IProxySelectionStore
     void SetSelection(string subscriptionId, string groupName, string proxyName);
 
     void RemoveSelection(string subscriptionId, string groupName);
+
+    // 订阅删除后其选择永远不会再被读取，必须显式清理，否则永久残留。
+    void RemoveSubscription(string subscriptionId);
 }

--- a/src/Stelliberty.Application/Proxies/ProxySelectionRestorer.cs
+++ b/src/Stelliberty.Application/Proxies/ProxySelectionRestorer.cs
@@ -164,7 +164,7 @@ public sealed class ProxySelectionRestorer(
             var config = await coreConfigProvider.LoadAsync(cancellationToken);
             latest = config;
 
-            if (IsReady(config)
+            if (config.IsFullyResolved
                 && MatchesExpectedConfig(expectedConfig, config)
                 && IsSameGroupSnapshot(previous, config))
             {
@@ -204,24 +204,6 @@ public sealed class ProxySelectionRestorer(
             string.Equals(pair.First.Name, pair.Second.Name, StringComparison.Ordinal)
             && string.Equals(pair.First.Type, pair.Second.Type, StringComparison.Ordinal)
             && pair.First.All.SequenceEqual(pair.Second.All, StringComparer.Ordinal));
-    }
-
-    private static bool IsReady(ProxyConfig config)
-    {
-        if (config.Groups.Count == 0)
-        {
-            return false;
-        }
-
-        var entryNames = new HashSet<string>(config.Nodes.Keys, StringComparer.Ordinal);
-        foreach (var group in config.Groups)
-        {
-            entryNames.Add(group.Name);
-        }
-
-        return config.Groups
-            .Where(group => group.IsManualSelectable)
-            .All(group => group.All.Count > 0 && group.All.All(entryNames.Contains));
     }
 
     private static bool MatchesExpectedConfig(ProxyConfig expected, ProxyConfig actual)

--- a/src/Stelliberty.Application/Proxies/ResilientProxyConfigLoader.cs
+++ b/src/Stelliberty.Application/Proxies/ResilientProxyConfigLoader.cs
@@ -10,6 +10,12 @@ public sealed class ResilientProxyConfigLoader
     private static readonly TimeSpan PrimaryReloadRetryDelay = TimeSpan.FromMilliseconds(250);
     private const int PrimaryReloadMaxAttempts = 20;
 
+    private volatile bool _isDegraded;
+    private int _suppressedFailureCount;
+
+    // 核心实时 API 持续不可用；调用方据此退避轮询。
+    public bool IsDegraded => _isDegraded;
+
     public async Task<ProxyConfig> LoadAsync(
         IProxyConfigProvider primary,
         IProxyConfigProvider? fallback,
@@ -22,19 +28,25 @@ public sealed class ResilientProxyConfigLoader
                 using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 timeout.CancelAfter(PrimaryLoadTimeout);
                 var config = await primary.LoadAsync(timeout.Token);
-                if (HasRuntimeProxyEntries(config) || fallback is null || attempt == PrimaryReloadMaxAttempts)
+                if (HasRuntimeProxyEntries(config))
+                {
+                    ReportRecovered();
+                    return config;
+                }
+
+                if (fallback is null || attempt == PrimaryReloadMaxAttempts)
                 {
                     return config;
                 }
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                AppLogger.Warning("Core proxy list load timed out");
+                ReportDegraded("Core proxy list load timed out");
                 break;
             }
             catch (Exception exception) when (exception is not OperationCanceledException)
             {
-                AppLogger.Warning($"Core proxy list load failed: {exception.Message}");
+                ReportDegraded($"Core proxy list load failed: {exception.Message}");
                 break;
             }
 
@@ -54,6 +66,32 @@ public sealed class ResilientProxyConfigLoader
         }
 
         return new ProxyConfig([], new Dictionary<string, ProxyNode>());
+    }
+
+    // 核心离线期间同一条消息会按轮询周期无限重复，只记首条并统计抑制量。
+    private void ReportDegraded(string message)
+    {
+        if (_isDegraded)
+        {
+            _suppressedFailureCount++;
+            return;
+        }
+
+        _isDegraded = true;
+        _suppressedFailureCount = 0;
+        AppLogger.Warning(message);
+    }
+
+    private void ReportRecovered()
+    {
+        if (!_isDegraded)
+        {
+            return;
+        }
+
+        _isDegraded = false;
+        AppLogger.Info($"Core proxy list load recovered: suppressed={_suppressedFailureCount}");
+        _suppressedFailureCount = 0;
     }
 
     private static bool HasRuntimeProxyEntries(ProxyConfig config)

--- a/src/Stelliberty.Application/Proxies/StoredProxySelectionConfigProvider.cs
+++ b/src/Stelliberty.Application/Proxies/StoredProxySelectionConfigProvider.cs
@@ -8,8 +8,7 @@ public sealed class StoredProxySelectionConfigProvider(
     IProxySelectionStore selectionStore,
     ISubscriptionSelectionStore subscriptionSelectionStore,
     ProxySelectionSyncState? syncState = null,
-    bool importCoreSelections = false,
-    bool pruneInvalidSelections = true) : IProxyConfigProvider, IProxyRuntimeSnapshotSource
+    bool importCoreSelections = false) : IProxyConfigProvider, IProxyRuntimeSnapshotSource
 {
     public ProxyRuntimeSnapshot? LastSnapshot => (inner as IProxyRuntimeSnapshotSource)?.LastSnapshot;
 
@@ -25,28 +24,13 @@ public sealed class StoredProxySelectionConfigProvider(
         var selections = new Dictionary<string, string>(
             selectionStore.GetSelections(subscriptionId),
             StringComparer.Ordinal);
-        if (pruneInvalidSelections && config.Groups.Count > 0)
-        {
-            RemoveInvalidStoredSelections(config, selections, subscriptionId);
-        }
-
-        if (importCoreSelections && syncState?.CanImportCoreSelections == true)
+        // 导入会删除核心侧查不到的固定选择，过渡期快照会误删用户实际有效的选择。
+        if (importCoreSelections && syncState?.CanImportCoreSelections == true && config.IsFullyResolved)
         {
             ImportCoreSelections(config, selections, subscriptionId);
         }
 
         return ApplyStoredSelections(config, selections);
-    }
-
-    public ProxyConfig ApplyStoredSelections(ProxyConfig config)
-    {
-        var subscriptionId = subscriptionSelectionStore.GetCurrentSubscriptionId();
-        if (string.IsNullOrWhiteSpace(subscriptionId))
-        {
-            return config;
-        }
-
-        return ApplyStoredSelections(config, subscriptionId);
     }
 
     public ProxyConfig ApplyStoredSelections(ProxyConfig config, string subscriptionId)
@@ -56,20 +40,10 @@ public sealed class StoredProxySelectionConfigProvider(
             selectionStore.GetSelections(subscriptionId));
     }
 
-    public void PruneInvalidStoredSelections(ProxyConfig config)
-    {
-        var subscriptionId = subscriptionSelectionStore.GetCurrentSubscriptionId();
-        if (string.IsNullOrWhiteSpace(subscriptionId) || config.Groups.Count == 0)
-        {
-            return;
-        }
-
-        PruneInvalidStoredSelections(config, subscriptionId);
-    }
-
     public void PruneInvalidStoredSelections(ProxyConfig config, string subscriptionId)
     {
-        if (config.Groups.Count == 0)
+        // 快照不完整时无法区分“节点已删除”和“候选项还没解析出来”。
+        if (!config.IsFullyResolved)
         {
             return;
         }

--- a/src/Stelliberty.Application/Subscriptions/SubscriptionDeleter.cs
+++ b/src/Stelliberty.Application/Subscriptions/SubscriptionDeleter.cs
@@ -1,18 +1,21 @@
 using Stelliberty.Domain.Subscriptions;
+using Stelliberty.Application.Proxies;
 using Stelliberty.Application.Rules;
 namespace Stelliberty.Application.Subscriptions;
 
 public sealed class SubscriptionDeleter(
     ISubscriptionStore subscriptionStore,
     ISubscriptionSelectionStore selectionStore,
-    ISelectedSubscriptionRuntimeStore? runtimeStore = null,
-    IRuleOverrideStore? ruleOverrideStore = null)
+    ISelectedSubscriptionRuntimeStore runtimeStore,
+    IRuleOverrideStore ruleOverrideStore,
+    IProxySelectionStore proxySelectionStore)
 {
     public void Delete(string subscriptionId)
     {
         subscriptionStore.Delete(subscriptionId);
-        runtimeStore?.Delete(subscriptionId);
-        ruleOverrideStore?.Delete(subscriptionId);
+        runtimeStore.Delete(subscriptionId);
+        ruleOverrideStore.Delete(subscriptionId);
+        proxySelectionStore.RemoveSubscription(subscriptionId);
 
         if (selectionStore.GetCurrentSubscriptionId() != subscriptionId)
         {

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -162,7 +162,7 @@ public sealed partial class App : Avalonia.Application
                 overrideStore,
                 runtimeStore,
                 ruleOverrideService: ruleOverrideService);
-            var subscriptionDeleter = new SubscriptionDeleter(subscriptionStore, subscriptionSelectionStore, runtimeStore, ruleOverrideStore);
+            var subscriptionDeleter = new SubscriptionDeleter(subscriptionStore, subscriptionSelectionStore, runtimeStore, ruleOverrideStore, proxySelectionStore);
             // Provider 同步和状态读取始终走核心管道，保持 Debug 和 Release 路径一致。
             var coreProviderClient = new PipeCoreProviderClient(HubStartupCoordinator.CorePipe);
             var providerCatalogLoader = new SelectedSubscriptionProviderCatalogLoader(

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -247,13 +247,11 @@ public sealed partial class App : Avalonia.Application
                 proxySelectionStore,
                 subscriptionSelectionStore,
                 proxySelectionSyncState,
-                importCoreSelections: true,
-                pruneInvalidSelections: false);
+                importCoreSelections: true);
             var fallbackProxyConfigProvider = new StoredProxySelectionConfigProvider(
                 fileRuntimeProxyConfigProvider,
                 proxySelectionStore,
-                subscriptionSelectionStore,
-                pruneInvalidSelections: false);
+                subscriptionSelectionStore);
             var proxySelectionRestorer = new ProxySelectionRestorer(
                 coreClient: proxyCoreClient,
                 coreConfigProvider: mihomoApiProxyConfigProvider,

--- a/src/Stelliberty.Desktop/AppRuntime.cs
+++ b/src/Stelliberty.Desktop/AppRuntime.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using Avalonia;
 using Avalonia.Media;
 #if DEBUG
-using Avalonia.Logging;
 using HotAvalonia;
 #endif
 using Stelliberty.Application.Diagnostics;
@@ -46,12 +45,7 @@ internal static class AppRuntime
             .UsePlatformDetect()
             .With(CreateFontManagerOptions());
 
-#if DEBUG
-        // HotAvalonia 只写 Avalonia 日志通道，接入应用日志后才能定位监听与重编译失败。
-        builder = builder.LogToDelegate(AppLogger.Debug, LogEventLevel.Information, nameof(HotAvalonia));
-#else
         builder = builder.LogToTrace();
-#endif
 
         if (OperatingSystem.IsLinux())
         {

--- a/src/Stelliberty.Desktop/Controls/Sparkline.cs
+++ b/src/Stelliberty.Desktop/Controls/Sparkline.cs
@@ -274,18 +274,18 @@ public sealed class Sparkline : Control
         _animationTimer.Start();
     }
 
-    // 播放时长跟随实测到达间隔：IPC 往返让真实间隔大于 SampleInterval，按标称值播放会留规律停顿。
+    // 播放时长取实测到达间隔的保守估计：被下一笔打断会丢弃残余进度并跳过对应位移，宁可提前播完留下不可见的短停顿。
     private void MeasureInterval(long now)
     {
         if (_lastSeriesAt > 0 && SampleInterval > TimeSpan.Zero)
         {
-            // 留 5% 余量，宁可被下一笔接续（亚像素快进）也不留停顿。
-            var target = TimeSpan.FromMilliseconds((now - _lastSeriesAt) * 1.05);
+            // 扣 2% 保证先播完；余量再大停顿就会可见。
+            var target = TimeSpan.FromMilliseconds((now - _lastSeriesAt) * 0.98);
             var lower = SampleInterval * 0.5;
             var upper = SampleInterval * 1.25;
             target = target < lower ? lower : target > upper ? upper : target;
-            // 变长立即跟上以消除停顿，变短缓慢收敛以免频繁打断。
-            _measuredInterval = _measuredInterval <= TimeSpan.Zero || target > _measuredInterval
+            // 变短立即跟上以免被打断，变长缓慢收敛以免一次慢帧长期顶高时长。
+            _measuredInterval = _measuredInterval <= TimeSpan.Zero || target < _measuredInterval
                 ? target
                 : _measuredInterval * 0.9 + target * 0.1;
         }

--- a/src/Stelliberty.Desktop/Controls/Sparkline.cs
+++ b/src/Stelliberty.Desktop/Controls/Sparkline.cs
@@ -3,11 +3,22 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Threading;
 
 namespace Stelliberty.Desktop.Controls;
 
+// 端点与曲线由同一进度逐帧计算，端点始终落在末段路径上。
 public sealed class Sparkline : Control
 {
+    private const double CurveTension = 1d / 6d;
+    private const double AxisShrinkThreshold = 0.55d;
+    private const double AxisFloor = 64 * 1024d;
+    private const double EndPointBorderThickness = 2d;
+    private const int AnimationFramesPerSecond = 30;
+    // 渲染中断（隐藏到托盘、切页）后序列跳多格，形变追赶代替瞬移；滚动多格会变成飞掠。
+    private static readonly TimeSpan MorphDuration = TimeSpan.FromMilliseconds(320);
+    private static readonly double[] AxisMantissas = [1d, 1.25d, 1.6d, 2d, 2.5d, 3.2d, 4d, 5d, 6.3d, 8d];
+
     public static readonly StyledProperty<IReadOnlyList<double>?> ValuesProperty =
         AvaloniaProperty.Register<Sparkline, IReadOnlyList<double>?>(nameof(Values));
 
@@ -20,15 +31,45 @@ public sealed class Sparkline : Control
     public static readonly StyledProperty<double> StrokeThicknessProperty =
         AvaloniaProperty.Register<Sparkline, double>(nameof(StrokeThickness), 2d);
 
-    public static readonly StyledProperty<double> MaximumProperty =
-        AvaloniaProperty.Register<Sparkline, double>(nameof(Maximum));
-
     public static readonly StyledProperty<bool> ShowEndPointProperty =
         AvaloniaProperty.Register<Sparkline, bool>(nameof(ShowEndPoint));
 
+    // 标称推送间隔，只作播放时长的基准与上下限；实际时长按实测到达间隔自适应。
+    public static readonly StyledProperty<TimeSpan> SampleIntervalProperty =
+        AvaloniaProperty.Register<Sparkline, TimeSpan>(nameof(SampleInterval), TimeSpan.FromSeconds(1));
+
+    private readonly DispatcherTimer _animationTimer = new()
+    {
+        Interval = TimeSpan.FromSeconds(1d / AnimationFramesPerSecond),
+    };
+    private IReadOnlyList<double>? _previousValues;
+    private IReadOnlyList<double>? _drawnValues;
+    private double[]? _morphFrom;
+    private long _seriesRevision;
+    private long _drawnRevision = -1;
+    private double _axisMax;
+    private double _progress;
+    private long _animationStartedAt;
+    private TimeSpan _measuredInterval;
+    private long _lastSeriesAt;
+    private double _lastCurveWidth = double.NaN;
+    private double _lastHeight = double.NaN;
+    private double _lastBottom = double.NaN;
+    private bool _isVisualDirty = true;
+    private IBrush? _anchoredSource;
+    private IBrush? _anchoredFill;
+    private double _anchoredTop = double.NaN;
+    private double _anchoredBottom = double.NaN;
+
     static Sparkline()
     {
-        AffectsRender<Sparkline>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, MaximumProperty, ShowEndPointProperty);
+        AffectsRender<Sparkline>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, ShowEndPointProperty, SampleIntervalProperty);
+    }
+
+    public Sparkline()
+    {
+        IsHitTestVisible = false;
+        _animationTimer.Tick += OnAnimationTick;
     }
 
     public IReadOnlyList<double>? Values
@@ -55,110 +96,542 @@ public sealed class Sparkline : Control
         set => SetValue(StrokeThicknessProperty, value);
     }
 
-    public double Maximum
-    {
-        get => GetValue(MaximumProperty);
-        set => SetValue(MaximumProperty, value);
-    }
-
     public bool ShowEndPoint
     {
         get => GetValue(ShowEndPointProperty);
         set => SetValue(ShowEndPointProperty, value);
     }
 
+    public TimeSpan SampleInterval
+    {
+        get => GetValue(SampleIntervalProperty);
+        set => SetValue(SampleIntervalProperty, value);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == ValuesProperty)
+        {
+            _seriesRevision++;
+            return;
+        }
+
+        if (change.Property == StrokeProperty
+            || change.Property == FillProperty
+            || change.Property == StrokeThicknessProperty
+            || change.Property == ShowEndPointProperty)
+        {
+            _isVisualDirty = true;
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        _animationTimer.Stop();
+        // 定格到终态：滚动靠 progress 对齐末格，形变直接落到目标。
+        _progress = 1;
+        _morphFrom = null;
+        base.OnDetachedFromVisualTree(e);
+    }
+
     public override void Render(DrawingContext context)
     {
         base.Render(context);
-        var values = Values;
+
+        var currentValues = Values;
         var width = Bounds.Width;
         var height = Bounds.Height;
-        if (values is null || values.Count < 2 || width <= 0 || height <= 0)
+        var dotRadius = Math.Max(3.5, StrokeThickness * 1.9);
+        var pad = ShowEndPoint
+            ? Math.Max(StrokeThickness, dotRadius + EndPointBorderThickness * 0.5)
+            : StrokeThickness;
+        var rightPad = ShowEndPoint ? dotRadius + EndPointBorderThickness : 0;
+        var curveWidth = width - rightPad;
+        if (currentValues is null || currentValues.Count < 2 || curveWidth <= 0 || height <= pad * 2)
         {
             return;
         }
 
-        var max = 0d;
-        for (var i = 0; i < values.Count; i++)
-        {
-            if (values[i] > max)
-            {
-                max = values[i];
-            }
-        }
-
-        if (Maximum > 0)
-        {
-            max = Maximum;
-        }
-
-        var pad = StrokeThickness;
         var bottom = height - pad;
-        var usable = bottom - pad;
-        if (usable <= 0)
+        var layoutChanged = Math.Abs(_lastCurveWidth - curveWidth) > 0.01d
+            || Math.Abs(_lastHeight - height) > 0.01d
+            || Math.Abs(_lastBottom - bottom) > 0.01d;
+        var seriesChanged = _drawnRevision != _seriesRevision;
+        if (layoutChanged || _isVisualDirty || _drawnValues is null || _previousValues is null)
         {
-            usable = height;
-            bottom = height;
+            SetStaticSeries(currentValues, curveWidth, height, bottom);
+        }
+        else if (seriesChanged)
+        {
+            // 形变未播完时继续形变，切回滚动会二次跳变。
+            if (_morphFrom is null && CanScrollTransition(_previousValues, currentValues))
+            {
+                SetScrollSeries(currentValues, curveWidth, height, bottom);
+            }
+            else
+            {
+                SetMorphSeries(currentValues, curveWidth, height, bottom);
+            }
         }
 
-        var scale = max > 0 ? usable / max : 0;
-
-        var dotRadius = Math.Max(3.5, StrokeThickness * 1.9);
-        var rightPad = ShowEndPoint ? dotRadius + 2 : 0;
-        var stepX = (width - rightPad) / (values.Count - 1);
-
-        var points = new Point[values.Count];
-        for (var i = 0; i < values.Count; i++)
+        var values = _drawnValues;
+        if (values is null)
         {
-            points[i] = new Point(stepX * i, bottom - values[i] * scale);
+            return;
         }
 
-        if (Fill is { } fill)
+        var stepX = curveWidth / (currentValues.Count - 1);
+        var isScrolling = values.Count == currentValues.Count + 1;
+        var offsetX = isScrolling ? -stepX * _progress : 0;
+        if (_morphFrom is { } morphFrom)
         {
-            var area = new StreamGeometry();
-            using (var ctx = area.Open())
-            {
-                ctx.BeginFigure(new Point(0, bottom), true);
-                ctx.LineTo(points[0]);
-                AppendSmoothCurve(ctx, points, height);
-                ctx.LineTo(new Point(points[^1].X, bottom));
-                ctx.EndFigure(true);
-            }
-            context.DrawGeometry(fill, null, area);
+            values = LerpSeries(morphFrom, values, EaseOut(_progress));
         }
 
-        if (Stroke is { } stroke)
+        var points = BuildPoints(values, stepX, offsetX, bottom, (bottom - pad) / _axisMax);
+        var visibleEnd = ResolveVisibleEnd(points, curveWidth, height);
+
+        using (context.PushClip(new Rect(0, 0, curveWidth, height)))
         {
-            var line = new StreamGeometry();
-            using (var ctx = line.Open())
-            {
-                ctx.BeginFigure(points[0], false);
-                AppendSmoothCurve(ctx, points, height);
-                ctx.EndFigure(false);
-            }
-            context.DrawGeometry(null, new Pen(stroke, StrokeThickness, lineCap: PenLineCap.Round, lineJoin: PenLineJoin.Round), line);
+            DrawFill(context, points, bottom, height, visibleEnd);
+            DrawLine(context, points, height, visibleEnd);
+        }
 
-            if (ShowEndPoint)
-            {
-
-                context.DrawEllipse(stroke, new Pen(Brushes.White, 2), points[^1], dotRadius, dotRadius);
-            }
+        if (ShowEndPoint && Stroke is { } stroke)
+        {
+            context.DrawEllipse(
+                stroke,
+                new Pen(Brushes.White, EndPointBorderThickness),
+                visibleEnd.Point,
+                dotRadius,
+                dotRadius);
         }
     }
 
-    private static void AppendSmoothCurve(StreamGeometryContext ctx, IReadOnlyList<Point> points, double height)
+    private void SetStaticSeries(IReadOnlyList<double> values, double curveWidth, double height, double bottom)
+    {
+        StopAnimation();
+        // 两个字段只读不改写，共享同一份快照。
+        var snapshot = CopyValues(values);
+        _drawnValues = snapshot;
+        _previousValues = snapshot;
+        _drawnRevision = _seriesRevision;
+        UpdateAxis(_drawnValues);
+        _lastCurveWidth = curveWidth;
+        _lastHeight = height;
+        _lastBottom = bottom;
+        _isVisualDirty = false;
+    }
+
+    private void SetScrollSeries(IReadOnlyList<double> currentValues, double curveWidth, double height, double bottom)
+    {
+        _drawnValues = AppendNewValue(_previousValues!, currentValues[^1]);
+        _previousValues = CopyValues(currentValues);
+        _drawnRevision = _seriesRevision;
+        UpdateAxis(_drawnValues);
+        _lastCurveWidth = curveWidth;
+        _lastHeight = height;
+        _lastBottom = bottom;
+        _isVisualDirty = false;
+        StartAnimation();
+    }
+
+    private void SetMorphSeries(IReadOnlyList<double> currentValues, double curveWidth, double height, double bottom)
+    {
+        if (ResolveMorphOrigin(currentValues.Count) is not { } origin)
+        {
+            SetStaticSeries(currentValues, curveWidth, height, bottom);
+            return;
+        }
+
+        var snapshot = CopyValues(currentValues);
+        _drawnValues = snapshot;
+        _previousValues = snapshot;
+        _morphFrom = origin;
+        _drawnRevision = _seriesRevision;
+        // 轴要同时容纳起点与目标，否则形变途中峰值被裁。
+        UpdateAxis(snapshot, Peak(origin));
+        _lastCurveWidth = curveWidth;
+        _lastHeight = height;
+        _lastBottom = bottom;
+        _isVisualDirty = false;
+        // 中断期间的到达间隔不可用于测速，清空基准。
+        _measuredInterval = TimeSpan.Zero;
+        _lastSeriesAt = 0;
+        _progress = 0;
+        _animationStartedAt = Environment.TickCount64;
+        _animationTimer.Start();
+    }
+
+    private double[]? ResolveMorphOrigin(int count)
+    {
+        if (_drawnValues is not { } drawn)
+        {
+            return null;
+        }
+
+        if (_morphFrom is { Length: > 0 } from && from.Length == count && drawn.Count == count)
+        {
+            return LerpSeries(from, drawn, EaseOut(_progress));
+        }
+
+        if (drawn.Count == count + 1)
+        {
+            // 滚动中的半格偏移用相邻采样混合近似。
+            var origin = new double[count];
+            for (var i = 0; i < count; i++)
+            {
+                origin[i] = drawn[i] + (drawn[i + 1] - drawn[i]) * _progress;
+            }
+
+            return origin;
+        }
+
+        return drawn.Count == count ? CopyValues(drawn) : null;
+    }
+
+    private void StartAnimation()
+    {
+        var now = Environment.TickCount64;
+        MeasureInterval(now);
+        _progress = 0;
+        _animationStartedAt = now;
+        _animationTimer.Start();
+    }
+
+    // 播放时长跟随实测到达间隔：IPC 往返让真实间隔大于 SampleInterval，按标称值播放会留规律停顿。
+    private void MeasureInterval(long now)
+    {
+        if (_lastSeriesAt > 0 && SampleInterval > TimeSpan.Zero)
+        {
+            // 留 5% 余量，宁可被下一笔接续（亚像素快进）也不留停顿。
+            var target = TimeSpan.FromMilliseconds((now - _lastSeriesAt) * 1.05);
+            var lower = SampleInterval * 0.5;
+            var upper = SampleInterval * 1.25;
+            target = target < lower ? lower : target > upper ? upper : target;
+            // 变长立即跟上以消除停顿，变短缓慢收敛以免频繁打断。
+            _measuredInterval = _measuredInterval <= TimeSpan.Zero || target > _measuredInterval
+                ? target
+                : _measuredInterval * 0.9 + target * 0.1;
+        }
+
+        _lastSeriesAt = now;
+    }
+
+    private void StopAnimation()
+    {
+        _animationTimer.Stop();
+        _progress = 0;
+        _morphFrom = null;
+    }
+
+    private void OnAnimationTick(object? sender, EventArgs e)
+    {
+        var isMorphing = _morphFrom is not null;
+        var duration = isMorphing
+            ? MorphDuration
+            : _measuredInterval > TimeSpan.Zero ? _measuredInterval : SampleInterval;
+        if (duration <= TimeSpan.Zero)
+        {
+            _progress = 1;
+            _animationTimer.Stop();
+        }
+        else
+        {
+            var elapsed = TimeSpan.FromMilliseconds(Environment.TickCount64 - _animationStartedAt);
+            _progress = Math.Clamp(elapsed / duration, 0, 1);
+            if (_progress >= 1)
+            {
+                _animationTimer.Stop();
+            }
+        }
+
+        // 收尾必须清起点，否则后续数据回不到横向滚动。
+        if (isMorphing && _progress >= 1)
+        {
+            _morphFrom = null;
+        }
+
+        InvalidateVisual();
+    }
+
+    private void UpdateAxis(IReadOnlyList<double> values, double extraPeak = 0)
+    {
+        var peak = Math.Max(Peak(values), extraPeak);
+
+        // 首帧全零时 peak 与 _axisMax 同为 0，换档条件都不成立，必须兜住除零。
+        if (_axisMax <= 0 || peak > _axisMax || peak < _axisMax * AxisShrinkThreshold)
+        {
+            _axisMax = ResolveAxisStep(Math.Max(peak, AxisFloor));
+        }
+    }
+
+    private static double Peak(IReadOnlyList<double> values)
+    {
+        var peak = 0d;
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (values[i] > peak)
+            {
+                peak = values[i];
+            }
+        }
+
+        return peak;
+    }
+
+    private void DrawFill(DrawingContext context, IReadOnlyList<Point> points, double bottom, double height, VisibleEnd visibleEnd)
+    {
+        if (ResolveFill(height - bottom, bottom) is not { } fill)
+        {
+            return;
+        }
+
+        var area = new StreamGeometry();
+        using (var geometry = area.Open())
+        {
+            geometry.BeginFigure(new Point(points[0].X, bottom), true);
+            geometry.LineTo(points[0]);
+            AppendSmoothCurve(geometry, points, height, visibleEnd);
+            geometry.LineTo(new Point(visibleEnd.Point.X, bottom));
+            geometry.EndFigure(true);
+        }
+
+        context.DrawGeometry(fill, null, area);
+    }
+
+    private void DrawLine(DrawingContext context, IReadOnlyList<Point> points, double height, VisibleEnd visibleEnd)
+    {
+        if (Stroke is not { } stroke)
+        {
+            return;
+        }
+
+        var line = new StreamGeometry();
+        using (var geometry = line.Open())
+        {
+            geometry.BeginFigure(points[0], false);
+            AppendSmoothCurve(geometry, points, height, visibleEnd);
+            geometry.EndFigure(false);
+        }
+
+        context.DrawGeometry(
+            null,
+            new Pen(stroke, StrokeThickness, lineCap: PenLineCap.Flat, lineJoin: PenLineJoin.Round),
+            line);
+    }
+
+    // 路径按圆点中心截断，不能依赖裁剪矩形处理最后一段的抗锯齿边缘。
+    private static VisibleEnd ResolveVisibleEnd(IReadOnlyList<Point> points, double endX, double height)
     {
         for (var i = 0; i < points.Count - 1; i++)
         {
+            var p1 = points[i];
+            var p2 = points[i + 1];
+            if (p1.X <= endX && p2.X >= endX)
+            {
+                var p0 = points[i == 0 ? 0 : i - 1];
+                var p3 = points[i + 2 < points.Count ? i + 2 : points.Count - 1];
+                GetCubicControls(p0, p1, p2, p3, height, out var c1, out var c2);
+                var u = SolveCurveParameter(p1.X, c1.X, c2.X, p2.X, endX);
+                SplitCubicAt(p1, c1, c2, p2, u, out var cutC1, out var cutC2, out var cutPoint);
+                return new VisibleEnd(i, u, cutC1, cutC2, cutPoint);
+            }
+        }
+
+        var last = points[^1];
+        return new VisibleEnd(points.Count - 2, 1, last, last, last);
+    }
+
+    // 渐变用绘图区绝对坐标锚定，避免峰值变化时按几何边界框重新映射。
+    private IBrush? ResolveFill(double top, double bottom)
+    {
+        if (Fill is not LinearGradientBrush gradient)
+        {
+            return Fill;
+        }
+
+        if (_anchoredFill is not null
+            && ReferenceEquals(_anchoredSource, gradient)
+            && Math.Abs(_anchoredTop - top) < 0.01d
+            && Math.Abs(_anchoredBottom - bottom) < 0.01d)
+        {
+            return _anchoredFill;
+        }
+
+        var anchored = new LinearGradientBrush
+        {
+            StartPoint = new RelativePoint(0, top, RelativeUnit.Absolute),
+            EndPoint = new RelativePoint(0, bottom, RelativeUnit.Absolute),
+            SpreadMethod = gradient.SpreadMethod,
+            Opacity = gradient.Opacity,
+        };
+        foreach (var stop in gradient.GradientStops)
+        {
+            anchored.GradientStops.Add(new GradientStop(stop.Color, stop.Offset));
+        }
+
+        _anchoredSource = gradient;
+        _anchoredTop = top;
+        _anchoredBottom = bottom;
+        _anchoredFill = anchored;
+        return anchored;
+    }
+
+    private static bool CanScrollTransition(IReadOnlyList<double> previous, IReadOnlyList<double> current)
+    {
+        if (previous.Count != current.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < current.Count - 1; i++)
+        {
+            if (previous[i + 1] != current[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static double[] AppendNewValue(IReadOnlyList<double> previous, double newValue)
+    {
+        var values = new double[previous.Count + 1];
+        for (var i = 0; i < previous.Count; i++)
+        {
+            values[i] = previous[i];
+        }
+
+        values[^1] = newValue;
+        return values;
+    }
+
+    private static double[] CopyValues(IReadOnlyList<double> values)
+    {
+        var copy = new double[values.Count];
+        for (var i = 0; i < values.Count; i++)
+        {
+            copy[i] = values[i];
+        }
+
+        return copy;
+    }
+
+    private static double[] LerpSeries(IReadOnlyList<double> from, IReadOnlyList<double> to, double t)
+    {
+        var values = new double[to.Count];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = from[i] + (to[i] - from[i]) * t;
+        }
+
+        return values;
+    }
+
+    private static double EaseOut(double t)
+    {
+        var rest = 1d - t;
+        return 1d - rest * rest * rest;
+    }
+
+    private static Point[] BuildPoints(IReadOnlyList<double> values, double stepX, double offsetX, double bottom, double scale)
+    {
+        var points = new Point[values.Count];
+        for (var i = 0; i < values.Count; i++)
+        {
+            points[i] = new Point(stepX * i + offsetX, bottom - values[i] * scale);
+        }
+
+        return points;
+    }
+
+    private static double ResolveAxisStep(double value)
+    {
+        var basis = Math.Pow(10, Math.Floor(Math.Log10(value)));
+        foreach (var mantissa in AxisMantissas)
+        {
+            var candidate = mantissa * basis;
+            if (candidate >= value)
+            {
+                return candidate;
+            }
+        }
+
+        return basis * 10d;
+    }
+
+    private static void AppendSmoothCurve(StreamGeometryContext context, IReadOnlyList<Point> points, double height, VisibleEnd visibleEnd)
+    {
+        for (var i = 0; i <= visibleEnd.SegmentIndex; i++)
+        {
+            if (i == visibleEnd.SegmentIndex && visibleEnd.Parameter < 1)
+            {
+                context.CubicBezierTo(visibleEnd.Control1, visibleEnd.Control2, visibleEnd.Point);
+                return;
+            }
+
             var p0 = points[i == 0 ? 0 : i - 1];
             var p1 = points[i];
             var p2 = points[i + 1];
             var p3 = points[i + 2 < points.Count ? i + 2 : points.Count - 1];
-
-            const double tension = 1d / 6d;
-            var c1 = new Point(p1.X + (p2.X - p0.X) * tension, Math.Clamp(p1.Y + (p2.Y - p0.Y) * tension, 0, height));
-            var c2 = new Point(p2.X - (p3.X - p1.X) * tension, Math.Clamp(p2.Y - (p3.Y - p1.Y) * tension, 0, height));
-            ctx.CubicBezierTo(c1, c2, p2);
+            GetCubicControls(p0, p1, p2, p3, height, out var c1, out var c2);
+            context.CubicBezierTo(c1, c2, p2);
         }
     }
+
+    private static void GetCubicControls(Point p0, Point p1, Point p2, Point p3, double height, out Point c1, out Point c2)
+    {
+        c1 = new Point(
+            p1.X + (p2.X - p0.X) * CurveTension,
+            Math.Clamp(p1.Y + (p2.Y - p0.Y) * CurveTension, 0, height));
+        c2 = new Point(
+            p2.X - (p3.X - p1.X) * CurveTension,
+            Math.Clamp(p2.Y - (p3.Y - p1.Y) * CurveTension, 0, height));
+    }
+
+    private static void SplitCubicAt(Point p0, Point p1, Point p2, Point p3, double u, out Point c1, out Point c2, out Point endpoint)
+    {
+        var q0 = Lerp(p0, p1, u);
+        var q1 = Lerp(p1, p2, u);
+        var q2 = Lerp(p2, p3, u);
+        var r0 = Lerp(q0, q1, u);
+        var r1 = Lerp(q1, q2, u);
+        endpoint = Lerp(r0, r1, u);
+        c1 = q0;
+        c2 = r0;
+    }
+
+    private static Point Lerp(Point start, Point end, double u)
+        => new(start.X + (end.X - start.X) * u, start.Y + (end.Y - start.Y) * u);
+
+    private static double SolveCurveParameter(double x0, double x1, double x2, double x3, double targetX)
+    {
+        var low = 0d;
+        var high = 1d;
+        for (var i = 0; i < 20; i++)
+        {
+            var middle = (low + high) * 0.5;
+            if (CubicAt(x0, x1, x2, x3, middle) < targetX)
+            {
+                low = middle;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        return (low + high) * 0.5;
+    }
+
+    private static double CubicAt(double a, double b, double c, double d, double u)
+    {
+        var v = 1d - u;
+        return v * v * v * a + 3 * v * v * u * b + 3 * v * u * u * c + u * u * u * d;
+    }
+
+    private readonly record struct VisibleEnd(int SegmentIndex, double Parameter, Point Control1, Point Control2, Point Point);
 }

--- a/src/Stelliberty.Desktop/Controls/Sparkline.cs
+++ b/src/Stelliberty.Desktop/Controls/Sparkline.cs
@@ -7,13 +7,12 @@ using Avalonia.Threading;
 
 namespace Stelliberty.Desktop.Controls;
 
-// 端点与曲线由同一进度逐帧计算，端点始终落在末段路径上。
+// 曲线按进度逐帧滚动或形变，末段在可视右边界处精确截断。
 public sealed class Sparkline : Control
 {
     private const double CurveTension = 1d / 6d;
     private const double AxisShrinkThreshold = 0.55d;
     private const double AxisFloor = 64 * 1024d;
-    private const double EndPointBorderThickness = 2d;
     private const int AnimationFramesPerSecond = 30;
     // 渲染中断（隐藏到托盘、切页）后序列跳多格，形变追赶代替瞬移；滚动多格会变成飞掠。
     private static readonly TimeSpan MorphDuration = TimeSpan.FromMilliseconds(320);
@@ -30,9 +29,6 @@ public sealed class Sparkline : Control
 
     public static readonly StyledProperty<double> StrokeThicknessProperty =
         AvaloniaProperty.Register<Sparkline, double>(nameof(StrokeThickness), 2d);
-
-    public static readonly StyledProperty<bool> ShowEndPointProperty =
-        AvaloniaProperty.Register<Sparkline, bool>(nameof(ShowEndPoint));
 
     // 标称推送间隔，只作播放时长的基准与上下限；实际时长按实测到达间隔自适应。
     public static readonly StyledProperty<TimeSpan> SampleIntervalProperty =
@@ -52,7 +48,7 @@ public sealed class Sparkline : Control
     private long _animationStartedAt;
     private TimeSpan _measuredInterval;
     private long _lastSeriesAt;
-    private double _lastCurveWidth = double.NaN;
+    private double _lastWidth = double.NaN;
     private double _lastHeight = double.NaN;
     private double _lastBottom = double.NaN;
     private bool _isVisualDirty = true;
@@ -63,7 +59,7 @@ public sealed class Sparkline : Control
 
     static Sparkline()
     {
-        AffectsRender<Sparkline>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, ShowEndPointProperty, SampleIntervalProperty);
+        AffectsRender<Sparkline>(ValuesProperty, StrokeProperty, FillProperty, StrokeThicknessProperty, SampleIntervalProperty);
     }
 
     public Sparkline()
@@ -96,12 +92,6 @@ public sealed class Sparkline : Control
         set => SetValue(StrokeThicknessProperty, value);
     }
 
-    public bool ShowEndPoint
-    {
-        get => GetValue(ShowEndPointProperty);
-        set => SetValue(ShowEndPointProperty, value);
-    }
-
     public TimeSpan SampleInterval
     {
         get => GetValue(SampleIntervalProperty);
@@ -119,8 +109,7 @@ public sealed class Sparkline : Control
 
         if (change.Property == StrokeProperty
             || change.Property == FillProperty
-            || change.Property == StrokeThicknessProperty
-            || change.Property == ShowEndPointProperty)
+            || change.Property == StrokeThicknessProperty)
         {
             _isVisualDirty = true;
         }
@@ -142,36 +131,31 @@ public sealed class Sparkline : Control
         var currentValues = Values;
         var width = Bounds.Width;
         var height = Bounds.Height;
-        var dotRadius = Math.Max(3.5, StrokeThickness * 1.9);
-        var pad = ShowEndPoint
-            ? Math.Max(StrokeThickness, dotRadius + EndPointBorderThickness * 0.5)
-            : StrokeThickness;
-        var rightPad = ShowEndPoint ? dotRadius + EndPointBorderThickness : 0;
-        var curveWidth = width - rightPad;
-        if (currentValues is null || currentValues.Count < 2 || curveWidth <= 0 || height <= pad * 2)
+        var pad = StrokeThickness;
+        if (currentValues is null || currentValues.Count < 2 || width <= 0 || height <= pad * 2)
         {
             return;
         }
 
         var bottom = height - pad;
-        var layoutChanged = Math.Abs(_lastCurveWidth - curveWidth) > 0.01d
+        var layoutChanged = Math.Abs(_lastWidth - width) > 0.01d
             || Math.Abs(_lastHeight - height) > 0.01d
             || Math.Abs(_lastBottom - bottom) > 0.01d;
         var seriesChanged = _drawnRevision != _seriesRevision;
         if (layoutChanged || _isVisualDirty || _drawnValues is null || _previousValues is null)
         {
-            SetStaticSeries(currentValues, curveWidth, height, bottom);
+            SetStaticSeries(currentValues, width, height, bottom);
         }
         else if (seriesChanged)
         {
             // 形变未播完时继续形变，切回滚动会二次跳变。
             if (_morphFrom is null && CanScrollTransition(_previousValues, currentValues))
             {
-                SetScrollSeries(currentValues, curveWidth, height, bottom);
+                SetScrollSeries(currentValues, width, height, bottom);
             }
             else
             {
-                SetMorphSeries(currentValues, curveWidth, height, bottom);
+                SetMorphSeries(currentValues, width, height, bottom);
             }
         }
 
@@ -181,7 +165,7 @@ public sealed class Sparkline : Control
             return;
         }
 
-        var stepX = curveWidth / (currentValues.Count - 1);
+        var stepX = width / (currentValues.Count - 1);
         var isScrolling = values.Count == currentValues.Count + 1;
         var offsetX = isScrolling ? -stepX * _progress : 0;
         if (_morphFrom is { } morphFrom)
@@ -190,26 +174,16 @@ public sealed class Sparkline : Control
         }
 
         var points = BuildPoints(values, stepX, offsetX, bottom, (bottom - pad) / _axisMax);
-        var visibleEnd = ResolveVisibleEnd(points, curveWidth, height);
+        var visibleEnd = ResolveVisibleEnd(points, width, height);
 
-        using (context.PushClip(new Rect(0, 0, curveWidth, height)))
+        using (context.PushClip(new Rect(0, 0, width, height)))
         {
             DrawFill(context, points, bottom, height, visibleEnd);
             DrawLine(context, points, height, visibleEnd);
         }
-
-        if (ShowEndPoint && Stroke is { } stroke)
-        {
-            context.DrawEllipse(
-                stroke,
-                new Pen(Brushes.White, EndPointBorderThickness),
-                visibleEnd.Point,
-                dotRadius,
-                dotRadius);
-        }
     }
 
-    private void SetStaticSeries(IReadOnlyList<double> values, double curveWidth, double height, double bottom)
+    private void SetStaticSeries(IReadOnlyList<double> values, double width, double height, double bottom)
     {
         StopAnimation();
         // 两个字段只读不改写，共享同一份快照。
@@ -218,30 +192,30 @@ public sealed class Sparkline : Control
         _previousValues = snapshot;
         _drawnRevision = _seriesRevision;
         UpdateAxis(_drawnValues);
-        _lastCurveWidth = curveWidth;
+        _lastWidth = width;
         _lastHeight = height;
         _lastBottom = bottom;
         _isVisualDirty = false;
     }
 
-    private void SetScrollSeries(IReadOnlyList<double> currentValues, double curveWidth, double height, double bottom)
+    private void SetScrollSeries(IReadOnlyList<double> currentValues, double width, double height, double bottom)
     {
         _drawnValues = AppendNewValue(_previousValues!, currentValues[^1]);
         _previousValues = CopyValues(currentValues);
         _drawnRevision = _seriesRevision;
         UpdateAxis(_drawnValues);
-        _lastCurveWidth = curveWidth;
+        _lastWidth = width;
         _lastHeight = height;
         _lastBottom = bottom;
         _isVisualDirty = false;
         StartAnimation();
     }
 
-    private void SetMorphSeries(IReadOnlyList<double> currentValues, double curveWidth, double height, double bottom)
+    private void SetMorphSeries(IReadOnlyList<double> currentValues, double width, double height, double bottom)
     {
         if (ResolveMorphOrigin(currentValues.Count) is not { } origin)
         {
-            SetStaticSeries(currentValues, curveWidth, height, bottom);
+            SetStaticSeries(currentValues, width, height, bottom);
             return;
         }
 
@@ -252,7 +226,7 @@ public sealed class Sparkline : Control
         _drawnRevision = _seriesRevision;
         // 轴要同时容纳起点与目标，否则形变途中峰值被裁。
         UpdateAxis(snapshot, Peak(origin));
-        _lastCurveWidth = curveWidth;
+        _lastWidth = width;
         _lastHeight = height;
         _lastBottom = bottom;
         _isVisualDirty = false;
@@ -422,7 +396,7 @@ public sealed class Sparkline : Control
             line);
     }
 
-    // 路径按圆点中心截断，不能依赖裁剪矩形处理最后一段的抗锯齿边缘。
+    // 路径按可视右边界精确截断，不能依赖裁剪矩形处理最后一段的抗锯齿边缘。
     private static VisibleEnd ResolveVisibleEnd(IReadOnlyList<Point> points, double endX, double height)
     {
         for (var i = 0; i < points.Count - 1; i++)

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Win32;
@@ -494,6 +495,9 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
             RedirectStandardError = true,
             RedirectStandardInput = command == "start-core",
             CreateNoWindow = true,
+            // 服务端输出 UTF-8；Windows 默认按 ANSI 解码会把中文系统错误变成乱码。
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
         info.ArgumentList.Add(command);
         return Process.Start(info);

--- a/src/Stelliberty.Desktop/Services/DesktopTrayService.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopTrayService.cs
@@ -7,6 +7,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Threading;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Localization;
+using Stelliberty.Application.Platform;
 using Stelliberty.Presentation.ViewModels;
 
 namespace Stelliberty.Desktop.Services;
@@ -122,6 +123,7 @@ internal sealed class DesktopTrayService : IDisposable
         _trayIcon = new TrayIcon
         {
             Icon = _icon,
+            ToolTipText = AppMetadata.DisplayName,
             Menu = new NativeMenu
             {
                 _showItem,

--- a/src/Stelliberty.Desktop/Views/HomeView.axaml
+++ b/src/Stelliberty.Desktop/Views/HomeView.axaml
@@ -273,7 +273,7 @@
                 <Border Grid.Row="2" BorderBrush="{DynamicResource AppBorderBrush}" BorderThickness="0,0,0,1" Opacity="0.5" />
                 <Border Grid.Row="3" BorderBrush="{DynamicResource AppBorderBrush}" BorderThickness="0,0,0,1" Opacity="0.5" />
               </Grid>
-              <controls:Sparkline ShowEndPoint="True" StrokeThickness="2.2"
+              <controls:Sparkline StrokeThickness="2.2"
                                   Stroke="{DynamicResource HomeUploadSeriesBrush}"
                                   Fill="{DynamicResource HomeUploadSeriesFillBrush}"
                                   Values="{Binding UploadSamples}">
@@ -287,7 +287,7 @@
                 <Border Grid.Row="2" BorderBrush="{DynamicResource AppBorderBrush}" BorderThickness="0,0,0,1" Opacity="0.5" />
                 <Border Grid.Row="3" BorderBrush="{DynamicResource AppBorderBrush}" BorderThickness="0,0,0,1" Opacity="0.5" />
               </Grid>
-              <controls:Sparkline ShowEndPoint="True" StrokeThickness="2.2"
+              <controls:Sparkline StrokeThickness="2.2"
                                   Stroke="{DynamicResource HomeDownloadSeriesBrush}"
                                   Fill="{DynamicResource HomeDownloadSeriesFillBrush}"
                                   Values="{Binding DownloadSamples}">

--- a/src/Stelliberty.Desktop/Views/HomeView.axaml.cs
+++ b/src/Stelliberty.Desktop/Views/HomeView.axaml.cs
@@ -1,11 +1,36 @@
 using Avalonia.Controls;
+using Stelliberty.Presentation.ViewModels;
 
 namespace Stelliberty.Desktop.Views;
 
-public sealed partial class HomeView : UserControl
+public sealed partial class HomeView : UserControl, IPageContentLifecycle
 {
+    private bool _isPageContentLive = true;
+
     public HomeView()
     {
         InitializeComponent();
+    }
+
+    void IPageContentLifecycle.ActivatePageContent() => ApplySpeedChartLive(true);
+
+    void IPageContentLifecycle.DeactivatePageContent() => ApplySpeedChartLive(false);
+
+    void IPageContentLifecycle.ReleasePageContent() => ApplySpeedChartLive(false);
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        // 视图重建时 DataContext 晚于激活回调到位，需补一次同步。
+        ApplySpeedChartLive(_isPageContentLive);
+    }
+
+    private void ApplySpeedChartLive(bool isLive)
+    {
+        _isPageContentLive = isLive;
+        if (DataContext is MainWindowViewModel viewModel)
+        {
+            viewModel.HomePage.SetSpeedChartLive(isLive);
+        }
     }
 }

--- a/src/Stelliberty.Domain/Proxies/ProxyConfig.cs
+++ b/src/Stelliberty.Domain/Proxies/ProxyConfig.cs
@@ -13,6 +13,28 @@ public sealed record ProxyConfig(
         _ => Groups.Where(g => !g.IsHidden && !IsGlobal(g)).ToList(),
     };
 
+    // 所有可选组的候选项都已解析；核心切换过渡期会返回缺条目的快照，据此才能安全清理已存选择。
+    public bool IsFullyResolved
+    {
+        get
+        {
+            if (Groups.Count == 0)
+            {
+                return false;
+            }
+
+            var entryNames = new HashSet<string>(Nodes.Keys, StringComparer.Ordinal);
+            foreach (var group in Groups)
+            {
+                entryNames.Add(group.Name);
+            }
+
+            return Groups
+                .Where(group => group.IsManualSelectable)
+                .All(group => group.All.Count > 0 && group.All.All(entryNames.Contains));
+        }
+    }
+
     private IReadOnlyList<ProxyGroup> GlobalVisibleGroups()
     {
         var global = Groups.FirstOrDefault(IsGlobal);

--- a/src/Stelliberty.Infrastructure/Proxies/FileProxySelectionStore.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/FileProxySelectionStore.cs
@@ -8,6 +8,8 @@ namespace Stelliberty.Infrastructure.Proxies;
 public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelectionStore
 {
     private readonly string _statePath = Path.Combine(rootDirectory, "proxies", "selection_state.json");
+    // 读改写必须串行：并发会丢更新，也会撞同一个原子替换临时文件。
+    private readonly object _syncRoot = new();
 
     public IReadOnlyDictionary<string, string> GetSelections(string subscriptionId)
     {
@@ -16,10 +18,13 @@ public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelect
             return new Dictionary<string, string>(StringComparer.Ordinal);
         }
 
-        var state = ReadState();
-        return state.Subscriptions.TryGetValue(subscriptionId, out var selections)
-            ? new Dictionary<string, string>(selections, StringComparer.Ordinal)
-            : new Dictionary<string, string>(StringComparer.Ordinal);
+        lock (_syncRoot)
+        {
+            var state = ReadState();
+            return state.Subscriptions.TryGetValue(subscriptionId, out var selections)
+                ? new Dictionary<string, string>(selections, StringComparer.Ordinal)
+                : new Dictionary<string, string>(StringComparer.Ordinal);
+        }
     }
 
     public void SetSelection(string subscriptionId, string groupName, string proxyName)
@@ -31,15 +36,19 @@ public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelect
             return;
         }
 
-        var state = ReadState();
-        if (!state.Subscriptions.TryGetValue(subscriptionId, out var selections))
+        lock (_syncRoot)
         {
-            selections = new Dictionary<string, string>(StringComparer.Ordinal);
-            state.Subscriptions[subscriptionId] = selections;
+            var state = ReadState();
+            if (!state.Subscriptions.TryGetValue(subscriptionId, out var selections))
+            {
+                selections = new Dictionary<string, string>(StringComparer.Ordinal);
+                state.Subscriptions[subscriptionId] = selections;
+            }
+
+            selections[groupName] = proxyName;
+            WriteState(state);
         }
 
-        selections[groupName] = proxyName;
-        WriteState(state);
         AppLogger.Info($"Proxy selection saved: subscription={subscriptionId} group={groupName} proxy={proxyName}");
     }
 
@@ -50,19 +59,23 @@ public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelect
             return;
         }
 
-        var state = ReadState();
-        if (!state.Subscriptions.TryGetValue(subscriptionId, out var selections)
-            || !selections.Remove(groupName))
+        lock (_syncRoot)
         {
-            return;
+            var state = ReadState();
+            if (!state.Subscriptions.TryGetValue(subscriptionId, out var selections)
+                || !selections.Remove(groupName))
+            {
+                return;
+            }
+
+            if (selections.Count == 0)
+            {
+                state.Subscriptions.Remove(subscriptionId);
+            }
+
+            WriteState(state);
         }
 
-        if (selections.Count == 0)
-        {
-            state.Subscriptions.Remove(subscriptionId);
-        }
-
-        WriteState(state);
         AppLogger.Info($"Proxy selection deleted: subscription={subscriptionId} group={groupName}");
     }
 
@@ -81,7 +94,7 @@ public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelect
         {
             WriteIndented = true
         });
-        File.WriteAllText(_statePath, json);
+        AtomicFile.WriteAllText(_statePath, json);
     }
 
     private sealed record SelectionState(Dictionary<string, Dictionary<string, string>> Subscriptions);

--- a/src/Stelliberty.Infrastructure/Proxies/FileProxySelectionStore.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/FileProxySelectionStore.cs
@@ -79,6 +79,27 @@ public sealed class FileProxySelectionStore(string rootDirectory) : IProxySelect
         AppLogger.Info($"Proxy selection deleted: subscription={subscriptionId} group={groupName}");
     }
 
+    public void RemoveSubscription(string subscriptionId)
+    {
+        if (string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            return;
+        }
+
+        lock (_syncRoot)
+        {
+            var state = ReadState();
+            if (!state.Subscriptions.Remove(subscriptionId))
+            {
+                return;
+            }
+
+            WriteState(state);
+        }
+
+        AppLogger.Info($"Proxy selections deleted: subscription={subscriptionId}");
+    }
+
     private SelectionState ReadState()
     {
         var state = JsonFileRecovery.ReadOrRecover<SelectionState>(_statePath);

--- a/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
+++ b/src/Stelliberty.Infrastructure/Proxies/PipeCoreProxyClient.cs
@@ -20,9 +20,15 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
     };
 
     private readonly HttpClient _client;
+    private readonly CancellationTokenSource _streamCancellation = new();
+    private int _isStreamStarted;
 
     // /memory 常从 0 开始；保留最后一个非零值以稳定界面。
     private long _lastMemoryInuse;
+    private long _trafficUpload;
+    private long _trafficDownload;
+    // 0 表示 /traffic 订阅还没拿到数据。
+    private long _trafficStampMs;
 
     public PipeCoreProxyClient(HttpClient client)
     {
@@ -36,6 +42,8 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
 
     public void Dispose()
     {
+        // 只取消不释放：订阅任务可能仍在 token 上等待。
+        _streamCancellation.Cancel();
         _client.Dispose();
     }
 
@@ -312,6 +320,7 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
 
     public async Task<CoreRuntimeStats?> GetRuntimeStatsAsync(CancellationToken cancellationToken = default)
     {
+        EnsureStreamSubscriptions();
         try
         {
             long uploadTotal;
@@ -333,16 +342,7 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
                     : 0;
             }
 
-            var trafficTask = GetTrafficAsync(cancellationToken);
-            var memoryTask = ReadMemoryInuseAsync(cancellationToken);
-            await Task.WhenAll(trafficTask, memoryTask);
-            var traffic = await trafficTask;
-            var memory = await memoryTask;
-            if (memory > 0)
-            {
-                Interlocked.Exchange(ref _lastMemoryInuse, memory);
-            }
-
+            var traffic = ReadCachedTraffic();
             return new CoreRuntimeStats(
                 traffic?.UploadSpeed ?? 0,
                 traffic?.DownloadSpeed ?? 0,
@@ -363,101 +363,106 @@ public sealed class PipeCoreProxyClient : IProxyCoreClient, IDisposable
         }
     }
 
-    public async Task<CoreTrafficRate?> GetTrafficAsync(CancellationToken cancellationToken = default)
+    // 速率取订阅缓存：/traffic 每秒推一行，逐次新建连接会平白等满一个推送周期。
+    public Task<CoreTrafficRate?> GetTrafficAsync(CancellationToken cancellationToken = default)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeout.CancelAfter(TimeSpan.FromSeconds(3));
-        try
+        EnsureStreamSubscriptions();
+        return Task.FromResult(ReadCachedTraffic());
+    }
+
+    private CoreTrafficRate? ReadCachedTraffic()
+    {
+        var stamp = Interlocked.Read(ref _trafficStampMs);
+        // 超过两个推送周期没有新行即视为失效，交由调用方改用总量差值。
+        if (stamp == 0 || Environment.TickCount64 - stamp > 2500)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, "traffic");
-            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
+            return null;
+        }
 
-            await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
-            using var reader = new StreamReader(stream);
-            string? line;
-            while ((line = await reader.ReadLineAsync(timeout.Token)) is not null)
-            {
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    continue;
-                }
+        return new CoreTrafficRate(
+            Interlocked.Read(ref _trafficUpload),
+            Interlocked.Read(ref _trafficDownload));
+    }
 
-                try
+    private void EnsureStreamSubscriptions()
+    {
+        if (Interlocked.CompareExchange(ref _isStreamStarted, 1, 0) != 0)
+        {
+            return;
+        }
+
+        var cancellationToken = _streamCancellation.Token;
+        _ = Task.Run(() => SubscribeStreamAsync("traffic", ApplyTrafficLine, cancellationToken), cancellationToken);
+        _ = Task.Run(() => SubscribeStreamAsync("memory", ApplyMemoryLine, cancellationToken), cancellationToken);
+    }
+
+    // 核心停止或重启会断开流；退避重连，不能忙等。
+    private async Task SubscribeStreamAsync(string path, Action<JsonElement> apply, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, path);
+                using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                if (response.IsSuccessStatusCode)
                 {
-                    using var doc = JsonDocument.Parse(line);
-                    var root = doc.RootElement;
-                    if (TryReadLong(root, "up", out var uploadSpeed) && TryReadLong(root, "down", out var downloadSpeed))
+                    await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                    using var reader = new StreamReader(stream);
+                    string? line;
+                    while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
                     {
-                        return new CoreTrafficRate(uploadSpeed, downloadSpeed);
+                        if (string.IsNullOrWhiteSpace(line))
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            using var doc = JsonDocument.Parse(line);
+                            apply(doc.RootElement);
+                        }
+                        catch (JsonException)
+                        {
+                        }
                     }
                 }
-                catch (JsonException)
-                {
-                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or IOException or ObjectDisposedException)
+            {
+                AppLogger.Debug($"Core {path} stream ended: {ex.Message}");
             }
 
-            return null;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException or OperationCanceledException)
-        {
-            AppLogger.Warning($"Core traffic read failed: {ex.Message}");
-            return null;
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
         }
     }
 
-    private async Task<long> ReadMemoryInuseAsync(CancellationToken cancellationToken)
+    private void ApplyTrafficLine(JsonElement root)
     {
-        // /memory 按行流式返回；遇到首个非零 inuse 或超时即停止。
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeout.CancelAfter(TimeSpan.FromSeconds(4));
-        try
+        if (TryReadLong(root, "up", out var uploadSpeed) && TryReadLong(root, "down", out var downloadSpeed))
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, "memory");
-            using var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
-            if (!response.IsSuccessStatusCode)
-            {
-                return 0;
-            }
-            await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
-            using var reader = new StreamReader(stream);
-            string? line;
-            while ((line = await reader.ReadLineAsync(timeout.Token)) is not null)
-            {
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    continue;
-                }
-                try
-                {
-                    using var doc = JsonDocument.Parse(line);
-                    var inuse = ReadLong(doc.RootElement, "inuse");
-                    if (inuse > 0)
-                    {
-                        return inuse;
-                    }
-                }
-                catch (JsonException)
-                {
-                }
-            }
+            Interlocked.Exchange(ref _trafficUpload, uploadSpeed);
+            Interlocked.Exchange(ref _trafficDownload, downloadSpeed);
+            Interlocked.Exchange(ref _trafficStampMs, Environment.TickCount64);
+        }
+    }
 
-            return 0;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    private void ApplyMemoryLine(JsonElement root)
+    {
+        if (TryReadLong(root, "inuse", out var inuse) && inuse > 0)
         {
-            throw;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException or OperationCanceledException)
-        {
-            return 0;
+            Interlocked.Exchange(ref _lastMemoryInuse, inuse);
         }
     }
 

--- a/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionSelectionStore.cs
+++ b/src/Stelliberty.Infrastructure/Subscriptions/FileSubscriptionSelectionStore.cs
@@ -8,20 +8,29 @@ namespace Stelliberty.Infrastructure.Subscriptions;
 public sealed class FileSubscriptionSelectionStore(string rootDirectory) : ISubscriptionSelectionStore
 {
     private readonly string _statePath = Path.Combine(rootDirectory, "subscriptions", "selection_state.json");
+    // 损坏文件会在读取时被改名重建，读写都要串行。
+    private readonly object _syncRoot = new();
 
     public string? GetCurrentSubscriptionId()
     {
-        return JsonFileRecovery.ReadOrRecover<SelectionState>(_statePath)?.CurrentSubscriptionId;
+        lock (_syncRoot)
+        {
+            return JsonFileRecovery.ReadOrRecover<SelectionState>(_statePath)?.CurrentSubscriptionId;
+        }
     }
 
     public void SetCurrentSubscriptionId(string? subscriptionId)
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(_statePath)!);
         var json = JsonSerializer.Serialize(new SelectionState(subscriptionId), new JsonSerializerOptions
         {
             WriteIndented = true
         });
-        File.WriteAllText(_statePath, json);
+
+        lock (_syncRoot)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_statePath)!);
+            AtomicFile.WriteAllText(_statePath, json);
+        }
     }
 
     private sealed record SelectionState(string? CurrentSubscriptionId);

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -462,6 +462,9 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
                     Post(() => ApplyRuntime(snapshot.Stats, snapshot.Mode, snapshot.Version, snapshot.ConnectionCount));
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
             catch (Exception exception)
             {
                 // 单次刷新失败不能覆盖当前运行状态。

--- a/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Home/HomePageViewModel.cs
@@ -66,17 +66,18 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
     private long _downloadTotal;
     private int _activeConnectionCount;
 
-    private double _speedAxisMax;
-
-    private const int SpeedHistoryCapacity = 60;
+    // 30 个采样间隔构成 30 秒可见窗口，故需 31 个点
+    private const int SpeedHistoryCapacity = 31;
     private readonly Queue<double> _uploadSpeedHistory = new();
     private readonly Queue<double> _downloadSpeedHistory = new();
+    private bool _isSpeedChartLive = true;
 
     private readonly TrafficRateTracker _trafficTracker = new();
     private bool _isCoreRestarting;
     private bool _isCoreUpdating;
     private bool _isServiceModeBusy;
     private bool _isRefreshingServiceMode;
+    private long _runtimeRefreshVersion;
     private bool _isDisposed;
     private ServiceModeStatus _serviceModeStatus = ServiceModeStatus.Unavailable(string.Empty);
     private DateTimeOffset? _lastServiceModeProbe;
@@ -205,9 +206,9 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         {
             _uptime = now >= since ? now - since : TimeSpan.Zero;
         }
-        else if (!isRunning)
+        else if (!isRunning && _isCoreRunning)
         {
-            // 核心停止只重置运行统计；系统代理有独立生命周期。
+            // 仅在运行转为停止时清空；初始与重复的停止状态不能打断图表采样。
             _coreRunningSince = null;
             _uptime = TimeSpan.Zero;
 
@@ -218,7 +219,6 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
             _downloadTotal = 0;
             _memoryValueText = null;
             _activeConnectionCount = 0;
-            _speedAxisMax = 0;
             SeedZeroHistory();
         }
 
@@ -353,11 +353,12 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     public string ActiveConnectionsValueText => _activeConnectionCount.ToString();
 
-    public double SpeedAxisMax => _speedAxisMax;
-
     public IReadOnlyList<double> UploadSamples { get; private set; } = Array.Empty<double>();
 
     public IReadOnlyList<double> DownloadSamples { get; private set; } = Array.Empty<double>();
+
+    // 曲线离开视野（窗口隐藏、切页）时冻结采样，回来后从离开位置接着走。
+    public void SetSpeedChartLive(bool isLive) => _isSpeedChartLive = isLive;
 
     public bool IsCoreRestarting => _isCoreRestarting;
 
@@ -397,6 +398,12 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     public void ApplyNetworkConnection(NetworkConnectionInfo info)
     {
+        // Post 投递后可能已销毁，销毁后不得再写状态。
+        if (_isDisposed)
+        {
+            return;
+        }
+
         _networkType = info.Type;
         _networkName = info.Name;
         RaiseHomeStateChanged();
@@ -441,12 +448,16 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
         var cancellationToken = _refreshCancellation.Token;
         var snapshotLoader = new CoreRuntimeSnapshotLoader(_proxyClient);
+        // 快照耗时常超过轮询周期，只应用最后发起的一次，避免总量倒退。
+        var refreshVersion = Interlocked.Increment(ref _runtimeRefreshVersion);
         _ = Task.Run(async () =>
         {
             try
             {
                 var snapshot = await snapshotLoader.LoadAsync(includeVersion: _shouldRefreshCoreVersion, cancellationToken);
-                if (snapshot is not null && !cancellationToken.IsCancellationRequested)
+                if (snapshot is not null
+                    && !cancellationToken.IsCancellationRequested
+                    && refreshVersion == Volatile.Read(ref _runtimeRefreshVersion))
                 {
                     Post(() => ApplyRuntime(snapshot.Stats, snapshot.Mode, snapshot.Version, snapshot.ConnectionCount));
                 }
@@ -527,6 +538,12 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
     private void ApplyRuntime(CoreRuntimeStats? stats, OutboundMode? mode, string? version, int? connectionCount)
     {
+        // 取消检查与 Post 投递之间存在窗口，销毁后不得再写状态。
+        if (_isDisposed)
+        {
+            return;
+        }
+
         if (stats is not null)
         {
             var sample = _trafficTracker.Update(stats.UploadTotal, stats.DownloadTotal, _now());
@@ -535,11 +552,13 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
             _uploadTotal = sample.UploadTotal;
             _downloadTotal = sample.DownloadTotal;
             _memoryValueText = ByteSize.Format(stats.Memory);
-            PushSpeedSample(_uploadSpeedHistory, _uploadSpeed);
-            PushSpeedSample(_downloadSpeedHistory, _downloadSpeed);
-            UploadSamples = _uploadSpeedHistory.ToArray();
-            DownloadSamples = _downloadSpeedHistory.ToArray();
-            _speedAxisMax = ComputeAxisMax(_uploadSpeedHistory, _downloadSpeedHistory);
+            if (_isSpeedChartLive)
+            {
+                PushSpeedSample(_uploadSpeedHistory, _uploadSpeed);
+                PushSpeedSample(_downloadSpeedHistory, _downloadSpeed);
+                UploadSamples = _uploadSpeedHistory.ToArray();
+                DownloadSamples = _downloadSpeedHistory.ToArray();
+            }
         }
 
         if (mode is { } coreMode)
@@ -1088,7 +1107,6 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         _downloadSpeed = 0;
         _uploadTotal = 0;
         _downloadTotal = 0;
-        _speedAxisMax = 0;
         // 重置回到首次进入时使用的零基线。
         SeedZeroHistory();
         RaiseHomeStateChanged();
@@ -1181,7 +1199,6 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
         OnPropertyChanged(nameof(ActiveConnectionsValueText));
         OnPropertyChanged(nameof(UploadSamples));
         OnPropertyChanged(nameof(DownloadSamples));
-        OnPropertyChanged(nameof(SpeedAxisMax));
         OnPropertyChanged(nameof(IsCoreRestarting));
         OnPropertyChanged(nameof(CanRestartCore));
         OnPropertyChanged(nameof(IsCoreUpdating));
@@ -1227,20 +1244,6 @@ public sealed class HomePageViewModel : ViewModelBase, IDisposable
 
         UploadSamples = _uploadSpeedHistory.ToArray();
         DownloadSamples = _downloadSpeedHistory.ToArray();
-    }
-
-    private static double ComputeAxisMax(Queue<double> upload, Queue<double> download)
-    {
-        var max = 0d;
-        foreach (var value in upload)
-        {
-            if (value > max) max = value;
-        }
-        foreach (var value in download)
-        {
-            if (value > max) max = value;
-        }
-        return max;
     }
 
     public void Dispose()

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.Navigation.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.Navigation.cs
@@ -116,7 +116,10 @@ public sealed partial class MainWindowViewModel
             await RunProxySelectionSyncOnceAsync(cancellation.Token);
             while (!cancellation.IsCancellationRequested)
             {
-                await Task.Delay(ProxySelectionSyncInterval, cancellation.Token);
+                var interval = ProxyPage.IsRuntimeConfigDegraded
+                    ? ProxySelectionSyncDegradedInterval
+                    : ProxySelectionSyncInterval;
+                await Task.Delay(interval, cancellation.Token);
                 await RunProxySelectionSyncOnceAsync(cancellation.Token);
             }
         }

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
@@ -58,6 +58,8 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
     private static readonly TimeSpan ToastCloseDuration = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan CoreLogFlushDelay = TimeSpan.FromMilliseconds(700);
     private static readonly TimeSpan ProxySelectionSyncInterval = TimeSpan.FromSeconds(2);
+    // 核心离线时每 2 秒重试只会打满日志与 IO，退到低频探活。
+    private static readonly TimeSpan ProxySelectionSyncDegradedInterval = TimeSpan.FromSeconds(15);
 
     public MainWindowViewModel(
         IAppSettingsStore settingsStore,

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/DelayTestCoordinator.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/DelayTestCoordinator.cs
@@ -1,0 +1,131 @@
+namespace Stelliberty.Presentation.ViewModels;
+
+// 延迟测试的进行中状态：批测持单一令牌，单测按节点各持一个令牌。
+// 正在测试的节点集合与忙标志一律由内部派生，外部只读，避免新增状态时漏更新派生量。
+internal sealed class DelayTestCoordinator
+{
+    private readonly Dictionary<string, CancellationTokenSource> _singleTests = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _batchTargetNodeNames = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _batchTestingNodeNames = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _batchResults = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _testingNodeNames = new(StringComparer.Ordinal);
+    private CancellationTokenSource? _batchCancellation;
+
+    public IReadOnlyCollection<string> TestingNodeNames => _testingNodeNames;
+
+    // 批测进行中收到的逐节点延迟，用于在整批结束前就渲染已完成的节点。
+    public IReadOnlyDictionary<string, int> BatchResults => _batchResults;
+
+    public bool IsBatchTesting => _batchCancellation is not null;
+
+    public bool IsTesting => IsBatchTesting || _singleTests.Count > 0;
+
+    public IReadOnlyList<string> ActiveSingleNodeNames => [.. _singleTests.Keys];
+
+    // 批测覆盖的节点不再接受单测，避免同一节点被两条链路同时测。
+    public bool IsBatchTarget(string nodeName) => _batchTargetNodeNames.Contains(nodeName);
+
+    public CancellationTokenSource BeginSingle(string nodeName)
+    {
+        // 只有同一节点被重复触发才取消它上一次的测试，不同节点互不影响。
+        if (_singleTests.Remove(nodeName, out var previous))
+        {
+            previous.Cancel();
+        }
+
+        var cancellation = new CancellationTokenSource();
+        _singleTests[nodeName] = cancellation;
+        RefreshTestingNodeNames();
+        return cancellation;
+    }
+
+    // 令牌已被取消或已被同节点的新测试顶替时，对应结果都不能再写回。
+    public bool IsSingleCurrent(string nodeName, CancellationTokenSource cancellation)
+    {
+        return !cancellation.IsCancellationRequested
+            && _singleTests.TryGetValue(nodeName, out var current)
+            && ReferenceEquals(current, cancellation);
+    }
+
+    public void CompleteSingle(string nodeName, CancellationTokenSource cancellation)
+    {
+        if (!_singleTests.TryGetValue(nodeName, out var current)
+            || !ReferenceEquals(current, cancellation))
+        {
+            return;
+        }
+
+        _singleTests.Remove(nodeName);
+        RefreshTestingNodeNames();
+    }
+
+    public CancellationTokenSource BeginBatch(IReadOnlyList<string> targetNodeNames)
+    {
+        _batchCancellation?.Cancel();
+        var cancellation = new CancellationTokenSource();
+        _batchCancellation = cancellation;
+        _batchTargetNodeNames.Clear();
+        _batchTargetNodeNames.UnionWith(targetNodeNames);
+        _batchTestingNodeNames.Clear();
+        _batchResults.Clear();
+        RefreshTestingNodeNames();
+        return cancellation;
+    }
+
+    public bool IsBatchCurrent(CancellationTokenSource cancellation)
+    {
+        return !cancellation.IsCancellationRequested
+            && ReferenceEquals(_batchCancellation, cancellation);
+    }
+
+    public void CompleteBatch(CancellationTokenSource cancellation)
+    {
+        if (!ReferenceEquals(_batchCancellation, cancellation))
+        {
+            return;
+        }
+
+        _batchCancellation = null;
+        _batchTargetNodeNames.Clear();
+        _batchTestingNodeNames.Clear();
+        _batchResults.Clear();
+        RefreshTestingNodeNames();
+    }
+
+    public void MarkBatchNodeTesting(string nodeName)
+    {
+        _batchTestingNodeNames.Add(nodeName);
+        RefreshTestingNodeNames();
+    }
+
+    public void MarkBatchNodeCompleted(string nodeName, int delay)
+    {
+        _batchTestingNodeNames.Remove(nodeName);
+        _batchResults[nodeName] = delay;
+        RefreshTestingNodeNames();
+    }
+
+    public void CancelAll()
+    {
+        _batchCancellation?.Cancel();
+        _batchCancellation = null;
+        // 只取消不释放：各发起方在自己的 finally 里释放自己的令牌。
+        foreach (var cancellation in _singleTests.Values)
+        {
+            cancellation.Cancel();
+        }
+
+        _singleTests.Clear();
+        _batchTargetNodeNames.Clear();
+        _batchTestingNodeNames.Clear();
+        _batchResults.Clear();
+        RefreshTestingNodeNames();
+    }
+
+    private void RefreshTestingNodeNames()
+    {
+        _testingNodeNames.Clear();
+        _testingNodeNames.UnionWith(_batchTestingNodeNames);
+        _testingNodeNames.UnionWith(_singleTests.Keys);
+    }
+}

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -446,6 +446,9 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         LoadConfig(await _resilientLoader.LoadAsync(primary, fallback, cancellationToken));
     }
 
+    // 核心实时 API 不可用；外部选择同步循环据此退避。
+    public bool IsRuntimeConfigDegraded => _resilientLoader.IsDegraded;
+
     public async Task SyncExternalSelectionsAsync(CancellationToken cancellationToken = default)
     {
         if (!_isPresentationActive

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -42,23 +42,15 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private bool _isCoreRunning;
     private readonly HashSet<string> _delayTestedNodeNames = new(StringComparer.Ordinal);
     private readonly HashSet<string> _batchDelayTestedNodeNames = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _delayTestingNodeNames = new(StringComparer.Ordinal);
 
     private string? _lastSelectedNodeName;
     private string? _locatedNodeName;
     private int _locateNodeRequestId;
     private ProxyChangeRequest? _lastChangeRequest;
-    private CancellationTokenSource? _batchDelayTestCancellation;
-    // 每个单测节点持有独立令牌，多个节点可同时测试而互不取消。
-    private readonly Dictionary<string, CancellationTokenSource> _singleDelayTests = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _batchDelayTargetNodeNames = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _batchDelayTestingNodeNames = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _batchDelayResults = new(StringComparer.Ordinal);
+    private readonly DelayTestCoordinator _delayTests = new();
     private bool _shouldCloseConnectionsAfterSelection;
     private bool _shouldChangeCoreOnSelection = true;
     private bool _shouldTestDelaysThroughService = true;
-    private bool _isDelayTesting;
-    private bool _isBatchDelayTesting;
     private bool _hasScrolledToTop;
     private int _scrollToTopRequestId;
     private int _configVersion;
@@ -241,11 +233,11 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public IReadOnlyCollection<string> BatchDelayTestedNodeNames => _batchDelayTestedNodeNames;
 
-    public IReadOnlyCollection<string> DelayTestingNodeNames => _delayTestingNodeNames;
+    public IReadOnlyCollection<string> DelayTestingNodeNames => _delayTests.TestingNodeNames;
 
-    public bool IsDelayTesting => _isDelayTesting;
+    public bool IsDelayTesting => _delayTests.IsTesting;
 
-    public bool IsBatchDelayTesting => _isBatchDelayTesting;
+    public bool IsBatchDelayTesting => _delayTests.IsBatchTesting;
 
     public bool IsPresentationActive => _isPresentationActive;
 
@@ -453,7 +445,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     {
         if (!_isPresentationActive
             || _primaryConfigProvider is null
-            || _isDelayTesting)
+            || _delayTests.IsTesting)
         {
             return;
         }
@@ -467,7 +459,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         {
             var config = await _resilientLoader.LoadAsync(_primaryConfigProvider, _fallbackConfigProvider, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            if (!_isPresentationActive || _isDelayTesting)
+            if (!_isPresentationActive || _delayTests.IsTesting)
             {
                 return;
             }
@@ -629,7 +621,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     public async Task TestNodeDelayAsync(string? nodeName)
     {
         if (string.IsNullOrWhiteSpace(nodeName)
-            || _batchDelayTargetNodeNames.Contains(nodeName))
+            || _delayTests.IsBatchTarget(nodeName))
         {
             return;
         }
@@ -794,8 +786,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
         if (!progress.IsCompleted)
         {
-            _batchDelayTestingNodeNames.Add(progress.ProxyName);
-            _delayTestingNodeNames.Add(progress.ProxyName);
+            _delayTests.MarkBatchNodeTesting(progress.ProxyName);
             if (_visibleNodeIndexes.TryGetValue(progress.ProxyName, out var testingIndex)
                 && _visibleNodeRows.GetRealizedRow(testingIndex) is { } testingRow)
             {
@@ -806,9 +797,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         }
 
         // 批量进度原地更新行；最终排序只刷新一次。
-        _batchDelayTestingNodeNames.Remove(progress.ProxyName);
-        _delayTestingNodeNames.Remove(progress.ProxyName);
-        _batchDelayResults[progress.ProxyName] = progress.Delay;
+        _delayTests.MarkBatchNodeCompleted(progress.ProxyName, progress.Delay);
         _delayTestedNodeNames.Add(progress.ProxyName);
         if (_visibleNodeIndexes.TryGetValue(progress.ProxyName, out var index)
             && _visibleNodeRows.GetRealizedRow(index) is { } row)
@@ -847,18 +836,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     public void CancelDelayTests()
     {
-        _batchDelayTestCancellation?.Cancel();
-        _batchDelayTestCancellation = null;
-        foreach (var cancellation in _singleDelayTests.Values)
-        {
-            cancellation.Cancel();
-        }
-
-        _singleDelayTests.Clear();
-        _batchDelayTargetNodeNames.Clear();
-        _batchDelayTestingNodeNames.Clear();
-        _batchDelayResults.Clear();
-        RefreshDelayTestingState();
+        _delayTests.CancelAll();
         RaiseProxyStateChanged();
     }
 
@@ -1000,7 +978,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     private void RefreshConfigIndexes()
     {
-        var visibleConfig = _config.WithEntryDelays(_batchDelayResults);
+        var visibleConfig = _config.WithEntryDelays(_delayTests.BatchResults);
         _visibleGroups = visibleConfig.VisibleGroups;
         var entryNodes = new Dictionary<string, ProxyNode>(visibleConfig.Nodes, StringComparer.Ordinal);
         foreach (var group in visibleConfig.Groups)
@@ -1105,8 +1083,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
             string.Equals(name, _selectedGroup?.DisplaySelectionName, StringComparison.Ordinal),
             string.Equals(name, _locatedNodeName, StringComparison.Ordinal),
             _selectedGroup?.IsManualSelectable == true,
-            _delayTestingNodeNames.Contains(name));
-        if (_batchDelayResults.TryGetValue(name, out var delay))
+            _delayTests.TestingNodeNames.Contains(name));
+        if (_delayTests.BatchResults.TryGetValue(name, out var delay))
         {
             row.ApplyDelay(delay);
         }
@@ -1121,7 +1099,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
             string.Equals(name, group?.DisplaySelectionName, StringComparison.Ordinal),
             string.Equals(name, _locatedNodeName, StringComparison.Ordinal),
             group?.IsManualSelectable == true,
-            _delayTestingNodeNames.Contains(name));
+            _delayTests.TestingNodeNames.Contains(name));
     }
 
     private void SyncGroupRows()
@@ -1230,90 +1208,46 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     private CancellationTokenSource BeginSingleDelayTest(string nodeName)
     {
-        // 只有同一节点被重复点击才取消它上一次的测试。
-        if (_singleDelayTests.Remove(nodeName, out var previous))
-        {
-            previous.Cancel();
-        }
-
-        var cancellation = new CancellationTokenSource();
-        _singleDelayTests[nodeName] = cancellation;
-        RefreshDelayTestingState();
+        var cancellation = _delayTests.BeginSingle(nodeName);
         RaiseProxyStateChanged();
         return cancellation;
     }
 
     private CancellationTokenSource BeginBatchDelayTest(IReadOnlyList<string> targetNodeNames)
     {
-        _batchDelayTestCancellation?.Cancel();
-        var cancellation = new CancellationTokenSource();
-        _batchDelayTestCancellation = cancellation;
-        _batchDelayTargetNodeNames.Clear();
-        _batchDelayTargetNodeNames.UnionWith(targetNodeNames);
-        _batchDelayTestingNodeNames.Clear();
-        _batchDelayResults.Clear();
-        RefreshDelayTestingState();
+        var cancellation = _delayTests.BeginBatch(targetNodeNames);
         RaiseProxyStateChanged();
         return cancellation;
     }
 
-    private IReadOnlyList<string> ActiveSingleDelayTestNames() => [.. _singleDelayTests.Keys];
+    private IReadOnlyList<string> ActiveSingleDelayTestNames() => _delayTests.ActiveSingleNodeNames;
 
+    // 配置换代后旧结果也算过期：延迟对应的是另一份节点表。
     private bool IsStaleSingleDelayResult(
         string nodeName,
         CancellationTokenSource cancellation,
         int configVersion)
     {
-        return cancellation.IsCancellationRequested
-            || !_singleDelayTests.TryGetValue(nodeName, out var current)
-            || !ReferenceEquals(current, cancellation)
+        return !_delayTests.IsSingleCurrent(nodeName, cancellation)
             || _configVersion != configVersion;
     }
 
     private bool IsStaleBatchDelayResult(CancellationTokenSource cancellation, int configVersion)
     {
-        return cancellation.IsCancellationRequested
-            || !ReferenceEquals(_batchDelayTestCancellation, cancellation)
+        return !_delayTests.IsBatchCurrent(cancellation)
             || _configVersion != configVersion;
     }
 
     private void CompleteSingleDelayTest(string nodeName, CancellationTokenSource cancellation)
     {
-        // 引用不一致说明该节点已被更新的测试接管，不能清掉后来者。
-        if (!_singleDelayTests.TryGetValue(nodeName, out var current)
-            || !ReferenceEquals(current, cancellation))
-        {
-            return;
-        }
-
-        _singleDelayTests.Remove(nodeName);
-        RefreshDelayTestingState();
+        _delayTests.CompleteSingle(nodeName, cancellation);
         RaiseProxyStateChanged();
     }
 
     private void CompleteBatchDelayTest(CancellationTokenSource cancellation)
     {
-        if (!ReferenceEquals(_batchDelayTestCancellation, cancellation))
-        {
-            return;
-        }
-
-        _batchDelayTestCancellation = null;
-        _batchDelayTargetNodeNames.Clear();
-        _batchDelayTestingNodeNames.Clear();
-        _batchDelayResults.Clear();
-        RefreshDelayTestingState();
+        _delayTests.CompleteBatch(cancellation);
         RaiseProxyStateChanged();
-    }
-
-    private void RefreshDelayTestingState()
-    {
-        _delayTestingNodeNames.Clear();
-        _delayTestingNodeNames.UnionWith(_batchDelayTestingNodeNames);
-        _delayTestingNodeNames.UnionWith(_singleDelayTests.Keys);
-
-        _isBatchDelayTesting = _batchDelayTestCancellation is not null;
-        _isDelayTesting = _isBatchDelayTesting || _singleDelayTests.Count > 0;
     }
 
     private void ApplyDelayResult(ProxyDelayResult result)
@@ -1328,7 +1262,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
                     return delay ?? -1;
                 },
                 StringComparer.Ordinal);
-        _config = _config.WithEntryDelays(delays).WithEntryDelays(_batchDelayResults);
+        _config = _config.WithEntryDelays(delays).WithEntryDelays(_delayTests.BatchResults);
         RefreshSelectedGroup();
     }
 

--- a/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/Proxies/ProxyPageViewModel.cs
@@ -49,8 +49,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     private int _locateNodeRequestId;
     private ProxyChangeRequest? _lastChangeRequest;
     private CancellationTokenSource? _batchDelayTestCancellation;
-    private CancellationTokenSource? _singleDelayTestCancellation;
-    private string? _singleDelayTestingNodeName;
+    // 每个单测节点持有独立令牌，多个节点可同时测试而互不取消。
+    private readonly Dictionary<string, CancellationTokenSource> _singleDelayTests = new(StringComparer.Ordinal);
     private readonly HashSet<string> _batchDelayTargetNodeNames = new(StringComparer.Ordinal);
     private readonly HashSet<string> _batchDelayTestingNodeNames = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _batchDelayResults = new(StringComparer.Ordinal);
@@ -849,9 +849,12 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     {
         _batchDelayTestCancellation?.Cancel();
         _batchDelayTestCancellation = null;
-        _singleDelayTestCancellation?.Cancel();
-        _singleDelayTestCancellation = null;
-        _singleDelayTestingNodeName = null;
+        foreach (var cancellation in _singleDelayTests.Values)
+        {
+            cancellation.Cancel();
+        }
+
+        _singleDelayTests.Clear();
         _batchDelayTargetNodeNames.Clear();
         _batchDelayTestingNodeNames.Clear();
         _batchDelayResults.Clear();
@@ -1227,10 +1230,14 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     private CancellationTokenSource BeginSingleDelayTest(string nodeName)
     {
-        _singleDelayTestCancellation?.Cancel();
+        // 只有同一节点被重复点击才取消它上一次的测试。
+        if (_singleDelayTests.Remove(nodeName, out var previous))
+        {
+            previous.Cancel();
+        }
+
         var cancellation = new CancellationTokenSource();
-        _singleDelayTestCancellation = cancellation;
-        _singleDelayTestingNodeName = nodeName;
+        _singleDelayTests[nodeName] = cancellation;
         RefreshDelayTestingState();
         RaiseProxyStateChanged();
         return cancellation;
@@ -1250,12 +1257,7 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         return cancellation;
     }
 
-    private IReadOnlyList<string> ActiveSingleDelayTestNames()
-    {
-        return _singleDelayTestingNodeName is null
-            ? []
-            : [_singleDelayTestingNodeName];
-    }
+    private IReadOnlyList<string> ActiveSingleDelayTestNames() => [.. _singleDelayTests.Keys];
 
     private bool IsStaleSingleDelayResult(
         string nodeName,
@@ -1263,8 +1265,8 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
         int configVersion)
     {
         return cancellation.IsCancellationRequested
-            || !ReferenceEquals(_singleDelayTestCancellation, cancellation)
-            || !string.Equals(_singleDelayTestingNodeName, nodeName, StringComparison.Ordinal)
+            || !_singleDelayTests.TryGetValue(nodeName, out var current)
+            || !ReferenceEquals(current, cancellation)
             || _configVersion != configVersion;
     }
 
@@ -1277,14 +1279,14 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
 
     private void CompleteSingleDelayTest(string nodeName, CancellationTokenSource cancellation)
     {
-        if (!ReferenceEquals(_singleDelayTestCancellation, cancellation)
-            || !string.Equals(_singleDelayTestingNodeName, nodeName, StringComparison.Ordinal))
+        // 引用不一致说明该节点已被更新的测试接管，不能清掉后来者。
+        if (!_singleDelayTests.TryGetValue(nodeName, out var current)
+            || !ReferenceEquals(current, cancellation))
         {
             return;
         }
 
-        _singleDelayTestCancellation = null;
-        _singleDelayTestingNodeName = null;
+        _singleDelayTests.Remove(nodeName);
         RefreshDelayTestingState();
         RaiseProxyStateChanged();
     }
@@ -1308,13 +1310,10 @@ public sealed class ProxyPageViewModel : ViewModelBase, IDisposable
     {
         _delayTestingNodeNames.Clear();
         _delayTestingNodeNames.UnionWith(_batchDelayTestingNodeNames);
-        if (_singleDelayTestingNodeName is not null)
-        {
-            _delayTestingNodeNames.Add(_singleDelayTestingNodeName);
-        }
+        _delayTestingNodeNames.UnionWith(_singleDelayTests.Keys);
 
         _isBatchDelayTesting = _batchDelayTestCancellation is not null;
-        _isDelayTesting = _isBatchDelayTesting || _singleDelayTestCancellation is not null;
+        _isDelayTesting = _isBatchDelayTesting || _singleDelayTests.Count > 0;
     }
 
     private void ApplyDelayResult(ProxyDelayResult result)


### PR DESCRIPTION
## Summary
- Restore proxy and subscription selections after an abrupt exit by writing selection state atomically and serializing read-modify-write
- Keep concurrent single node delay tests independent so each node holds its own cancellation token
- Clear stored proxy selections when a subscription is deleted
- Stream core traffic and memory stats on the home page and scroll the traffic curves smoothly
- Stop the traffic curve from jumping every second by keeping playback just below the measured arrival interval
- Remove the end point dot from the traffic curves
- Show the app name on tray icon hover
- Extract delay test state into DelayTestCoordinator so the testing node set and busy flags are derived rather than hand-maintained
- Publish the v2.0.28 release summary

## Validation
- `python scripts/test.py --all` (6 suites passed)
- `dotnet format Stelliberty.slnx --verify-no-changes` clean
- Packaged Debug build verified through the app debug harness: concurrent single node delay tests stay independent, batch and single tests coexist, cancel clears all testing state
- Traffic curve playback measured in-app: every sample now completes its animation instead of being cut at 93%
