### PR TITLE
Release v2.0.30

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,15 +1,11 @@
-- Fixed manually picking a node in a url-test or fallback group permanently suspending its automatic selection, which previously could only be undone by deleting the subscription
-- Running a delay test now releases manual picks on url-test and fallback groups, and a restart returns them to automatic selection
-- Fixed batch delay results disappearing from rows that scrolled out of view while the batch was still running
-- Dialogs now open scrolled to the top instead of keeping the position left by the previous session
-- Filtered rule lists now show the same centered empty card as the other list pages
-- Add and refresh moved into the rule page header, so the toolbar no longer overlaps at the narrowest window width
+- Applying config changes in service mode now reloads the core in place, so proxies no longer drop for a few seconds on subscription updates and setting changes
+- Fixed service-mode core status briefly showing as unavailable while the core kept running, which also caused unnecessary proxy selection reloads
+- Fixed a race during app shutdown that could crash the app while disposing the service-mode core client
+- Added a --minimized startup flag that launches the app with the main window minimized
 
 ---
 
-- 修复了在 url-test 或 fallback 分组手动选择节点后自动择优被永久挂起的问题，该问题此前只能通过删除订阅解除
-- 测试延迟现在会解除 url-test 和 fallback 分组的手动选择，重启后这类分组也会回到自动择优
-- 修复了批量测速期间滚出视图的条目丢失延迟结果的问题
-- 弹窗现在每次打开都从顶部开始，不再保留上一次的滚动位置
-- 规则列表被过滤为空时，现在显示与其它列表页一致的居中空状态卡片
-- 规则页的新增和刷新移入页头，最窄窗口宽度下工具栏不再重叠
+- 服务模式下应用配置变更改为原地重载核心，更新订阅或修改设置时代理节点不再短暂丢失
+- 修复了服务模式下核心仍在运行时状态短暂显示为不可用的问题，该问题此前还会引发多余的代理选择重载
+- 修复了应用退出时服务模式核心客户端释放竞态可能导致崩溃的问题
+- 新增了 --minimized 启动参数，现在可以让应用以主窗口最小化的方式启动

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "stelliberty_service"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "hub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,9 +1708,11 @@ name = "stelliberty_service"
 version = "1.0.1"
 dependencies = [
  "anyhow",
+ "hub",
  "libc",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "time",
  "tokio",
  "windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "nom",
  "p256",
  "pin-project",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
@@ -83,7 +83,7 @@ dependencies = [
  "hpke",
  "io_tee",
  "nom",
- "rand 0.8.7",
+ "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
 ]
@@ -126,7 +126,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -188,9 +188,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -215,12 +215,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -406,7 +406,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchers"
@@ -1269,7 +1269,7 @@ dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1298,9 +1298,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1313,7 +1313,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -1584,7 +1584,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1620,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -1642,7 +1642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638c0720e7c1f61722366256d369ea46139634e77738735d6d9bb287bbbad35f"
+checksum = "52fca06a22977165c6821c26e2bf0387cd7e0822107a6854d5fbb787307c4194"
 dependencies = [
  "serde",
 ]
@@ -1816,7 +1816,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "zerofrom",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <AppName>stelliberty</AppName>
     <AppDisplayName>Stelliberty</AppDisplayName>
-    <AppVersion>2.0.29</AppVersion>
+    <AppVersion>2.0.30</AppVersion>
     <AppPipePrefix>stelliberty</AppPipePrefix>
   </PropertyGroup>
 

--- a/native/hub/src/infra/core_runtime.rs
+++ b/native/hub/src/infra/core_runtime.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -167,9 +167,9 @@ impl CoreRuntime {
             inner.desired_yaml.clone()
         };
         // 先写 bootstrap，让活动 YAML 差异基线匹配核心实际配置。
-        std::fs::write(&self.paths.bootstrap_yaml, desired_yaml)
+        std::fs::write(&self.paths.bootstrap_yaml, &desired_yaml)
             .context("Failed to write bootstrap yaml")?;
-        let (initial_yaml, _) = self.rewrite_active_yaml(&self.paths.bootstrap_yaml).await?;
+        let (initial_yaml, _) = self.rewrite_active_yaml(&desired_yaml)?;
         let log_level = read_log_level(&initial_yaml);
         {
             let mut inner = self.state.lock().await;
@@ -324,7 +324,7 @@ impl CoreRuntime {
         self.paths.ensure_dirs()?;
         std::fs::write(&self.paths.bootstrap_yaml, &desired_yaml)
             .context("Failed to write bootstrap yaml")?;
-        let (active_yaml, _) = self.rewrite_active_yaml(&self.paths.bootstrap_yaml).await?;
+        let (active_yaml, _) = self.rewrite_active_yaml(&desired_yaml)?;
         let log_level = read_log_level(&active_yaml);
         self.start_core_process(
             &self.paths.active_yaml,
@@ -337,14 +337,9 @@ impl CoreRuntime {
         .await
     }
 
-    async fn rewrite_active_yaml(
-        &self,
-        source_path: &Path,
-    ) -> Result<(serde_yaml_ng::Value, String)> {
-        let text = std::fs::read_to_string(source_path)
-            .with_context(|| format!("Failed to read runtime yaml: {}", source_path.display()))?;
+    fn rewrite_active_yaml(&self, runtime_yaml: &str) -> Result<(serde_yaml_ng::Value, String)> {
         let mut yaml: serde_yaml_ng::Value =
-            serde_yaml_ng::from_str(&text).context("Failed to parse yaml")?;
+            serde_yaml_ng::from_str(runtime_yaml).context("Failed to parse yaml")?;
         if let serde_yaml_ng::Value::Mapping(map) = &mut yaml {
             // 只保留当前平台控制器端点，避免过期内联通道。
             #[cfg(unix)]
@@ -365,7 +360,7 @@ impl CoreRuntime {
 
     pub async fn apply_config(
         &self,
-        runtime_yaml_path: PathBuf,
+        runtime_yaml: String,
         _subscription_id: String,
     ) -> std::result::Result<serde_json::Value, ErrorBody> {
         let _lifecycle = self.lifecycle.lock().await;
@@ -379,7 +374,7 @@ impl CoreRuntime {
             }
         }
 
-        let (new_yaml, desired_yaml) = match self.rewrite_active_yaml(&runtime_yaml_path).await {
+        let (new_yaml, desired_yaml) = match self.rewrite_active_yaml(&runtime_yaml) {
             Ok(v) => v,
             Err(e) => {
                 return Err(ErrorBody {
@@ -526,19 +521,20 @@ impl MethodHandler for CoreRuntime {
                 Ok(serde_json::json!({ "pid": inner.child.as_ref().map(|c| c.pid) }))
             }
             "core.apply_config" => {
-                let path = params
-                    .get("runtime_yaml_path")
+                let runtime_yaml = params
+                    .get("runtime_yaml_content")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| ErrorBody {
                         code: "hub.internal".into(),
-                        message: "params is missing runtime_yaml_path".into(),
-                    })?;
+                        message: "params is missing runtime_yaml_content".into(),
+                    })?
+                    .to_string();
                 let sub_id = params
                     .get("subscription_id")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
-                self.apply_config(PathBuf::from(path), sub_id).await
+                self.apply_config(runtime_yaml, sub_id).await
             }
             other => Err(ErrorBody {
                 code: "hub.internal".into(),

--- a/native/hub/src/infra/ipc.rs
+++ b/native/hub/src/infra/ipc.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{Mutex, broadcast, mpsc};
 
-// 单帧上限 1 MiB；超大流会立即停止读取。
-pub const MAX_LINE_BYTES: usize = 1024 * 1024;
+// 单帧上限 4 MiB；配置内容随 payload 传输，预留 JSON 转义膨胀余量。
+pub const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/native/service/Cargo.toml
+++ b/native/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stelliberty_service"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 publish = false
 

--- a/native/service/Cargo.toml
+++ b/native/service/Cargo.toml
@@ -14,8 +14,10 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "^1.0.102"
+hub = { path = "../hub" }
 serde = { version = "^1.0.228", features = ["derive"] }
 serde_json = "^1.0.145"
+serde_yaml_ng = "^0.10.0"
 time = { version = "^0.3", features = ["formatting", "local-offset"] }
 tokio = { version = "^1.48", features = ["rt-multi-thread", "macros", "net", "io-util", "time", "signal", "sync", "process"] }
 

--- a/native/service/src/core.rs
+++ b/native/service/src/core.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
+use hub::infra::core_api::{ApiError, CoreApiClient};
+use hub::util::yaml_diff;
 use serde::Serialize;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -13,6 +15,15 @@ use crate::logging;
 const CORE_LOCK_SUFFIX: &str = ".lock";
 // 核心停止固定 5 秒；服务退出时锁等待也计入该预算。
 const CORE_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub const APPLY_MODE_RELOAD: &str = "reload";
+pub const APPLY_MODE_RESTART: &str = "restart";
+
+// mihomo 控制器端点按平台取字段；缺失时不可重载
+#[cfg(windows)]
+const CONTROLLER_FIELD: &str = "external-controller-pipe";
+#[cfg(not(windows))]
+const CONTROLLER_FIELD: &str = "external-controller-unix";
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -40,6 +51,8 @@ struct CoreInner {
     state: CoreState,
     child: Option<ChildHandle>,
     last_request: Option<StartCoreRequest>,
+    // spawn 或重载时应用的配置内容，作为下次 apply 的 diff 基准
+    last_applied_yaml: Option<serde_yaml_ng::Value>,
     last_error: Option<String>,
     restore_after_heartbeat: bool,
     restore_in_progress: bool,
@@ -61,6 +74,7 @@ impl CoreManager {
                 state: CoreState::Stopped,
                 child: None,
                 last_request: None,
+                last_applied_yaml: None,
                 last_error: None,
                 restore_after_heartbeat: false,
                 restore_in_progress: false,
@@ -78,6 +92,8 @@ impl CoreManager {
 
     async fn start_locked(&self, request: StartCoreRequest) -> Result<u32> {
         validate_start_request(&request)?;
+        // 记录 spawn 时刻的配置内容，作为后续重载的 diff 基准
+        let applied_yaml = read_applied_yaml(&request.config_path);
         self.stop_with_restore_flag_locked(false, CORE_STOP_TIMEOUT)
             .await?;
         let killed = self.cleanup_orphan_cores_checked().await?;
@@ -94,6 +110,7 @@ impl CoreManager {
             inner.generation += 1;
             inner.state = CoreState::Running;
             inner.last_request = Some(request);
+            inner.last_applied_yaml = applied_yaml;
             inner.last_error = None;
             inner.restore_after_heartbeat = false;
             inner.restore_in_progress = false;
@@ -142,6 +159,86 @@ impl CoreManager {
         self.start_locked(request).await
     }
 
+    // 应用新配置：启动期字段未变时优先重载，否则回退重启
+    pub async fn apply_config(&self, config_path: String) -> Result<CoreApplyOutcome> {
+        let _guard = self.lifecycle.lock().await;
+        validate_config_path(&config_path)?;
+        let yaml_text = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read core config: {config_path}"))?;
+        let new_yaml: serde_yaml_ng::Value =
+            serde_yaml_ng::from_str(&yaml_text).context("Failed to parse core config yaml")?;
+
+        if let Some(pid) = self.reloadable_pid(&new_yaml).await
+            && let Some(pipe) = controller_endpoint(&new_yaml)
+        {
+            match self.reload_core(&pipe, &config_path).await {
+                ReloadOutcome::Applied => {
+                    let mut inner = self.inner.lock().await;
+                    inner.last_applied_yaml = Some(new_yaml);
+                    logging::info(format!("Core config reloaded by service: pid={pid}"));
+                    return Ok(CoreApplyOutcome {
+                        mode: APPLY_MODE_RELOAD,
+                        pid,
+                    });
+                }
+                // mihomo 拒绝候选配置时不能回退重启，否则会保留坏配置
+                ReloadOutcome::Rejected(error) => return Err(error),
+                ReloadOutcome::Failed(error) => {
+                    logging::warn(format!(
+                        "Core reload failed; falling back to restart: {error:#}"
+                    ));
+                }
+            }
+        }
+
+        // 回退重启：复用已记录的启动参数，仅替换配置路径
+        let mut request = {
+            let inner = self.inner.lock().await;
+            inner
+                .last_request
+                .clone()
+                .ok_or_else(|| anyhow!("Core startup parameters are missing"))?
+        };
+        request.config_path = config_path;
+        let pid = self.start_locked(request).await?;
+        Ok(CoreApplyOutcome {
+            mode: APPLY_MODE_RESTART,
+            pid,
+        })
+    }
+
+    // 仅当核心在运行且启动期字段无差异时才可重载
+    async fn reloadable_pid(&self, new_yaml: &serde_yaml_ng::Value) -> Option<u32> {
+        let inner = self.inner.lock().await;
+        let pid = match (&inner.state, inner.child.as_ref()) {
+            (CoreState::Running, Some(child)) => child.pid,
+            _ => return None,
+        };
+        let unchanged = inner
+            .last_applied_yaml
+            .as_ref()
+            .is_some_and(|prev| !yaml_diff::needs_restart(prev, new_yaml));
+        unchanged.then_some(pid)
+    }
+
+    async fn reload_core(&self, pipe: &str, config_path: &str) -> ReloadOutcome {
+        let client = CoreApiClient::new(pipe);
+        match client.put_config_path(Path::new(config_path)).await {
+            Ok(()) => {
+                if let Err(error) = client.close_all_connections().await {
+                    logging::warn(format!(
+                        "Failed to close core connections after reload: {error:#}"
+                    ));
+                }
+                ReloadOutcome::Applied
+            }
+            Err(error) => match error.downcast_ref::<ApiError>() {
+                Some(ApiError::ConfigRejected(_)) => ReloadOutcome::Rejected(error),
+                _ => ReloadOutcome::Failed(error),
+            },
+        }
+    }
+
     pub async fn stop(&self) -> Result<()> {
         let _guard = self.lifecycle.lock().await;
         self.stop_with_restore_flag_locked(false, CORE_STOP_TIMEOUT)
@@ -184,6 +281,7 @@ impl CoreManager {
         let mut inner = self.inner.lock().await;
         if inner.generation == generation {
             inner.state = CoreState::Stopped;
+            inner.last_applied_yaml = None;
             inner.restore_after_heartbeat = restore_after_heartbeat && inner.last_request.is_some();
             inner.restore_in_progress = false;
         }
@@ -258,10 +356,48 @@ impl CoreManager {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct CoreApplyOutcome {
+    pub mode: &'static str,
+    pub pid: u32,
+}
+
+enum ReloadOutcome {
+    Applied,
+    // 4xx 被拒：候选配置有误，调用方不得回退重启
+    Rejected(anyhow::Error),
+    Failed(anyhow::Error),
+}
+
+fn controller_endpoint(yaml: &serde_yaml_ng::Value) -> Option<String> {
+    let key = serde_yaml_ng::Value::String(CONTROLLER_FIELD.to_string());
+    match yaml {
+        serde_yaml_ng::Value::Mapping(map) => map.get(&key)?.as_str().map(str::to_owned),
+        _ => None,
+    }
+}
+
+// 读不到仅降级为下次 apply 走重启，不阻塞启动
+fn read_applied_yaml(config_path: &str) -> Option<serde_yaml_ng::Value> {
+    let text = match std::fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) => {
+            logging::warn(format!("Failed to read applied core config: {error:#}"));
+            return None;
+        }
+    };
+    match serde_yaml_ng::from_str(&text) {
+        Ok(yaml) => Some(yaml),
+        Err(error) => {
+            logging::warn(format!("Failed to parse applied core config: {error}"));
+            None
+        }
+    }
+}
+
 fn validate_start_request(request: &StartCoreRequest) -> Result<()> {
     let allowed = AllowedCorePaths::resolve()?;
     let mihomo_path = canonical_file(&request.mihomo_path, "core executable")?;
-    let config_path = canonical_file(&request.config_path, "core config")?;
     let data_core_dir = canonical_dir(&request.data_core_dir, "core data directory")?;
 
     if !same_path(&mihomo_path, &allowed.mihomo_path) {
@@ -272,7 +408,16 @@ fn validate_start_request(request: &StartCoreRequest) -> Result<()> {
         return Err(anyhow!("Core data directory is outside the allowed area"));
     }
 
-    if !config_path.starts_with(&allowed.runtime_dir) {
+    validate_config_path(&request.config_path)?;
+
+    Ok(())
+}
+
+fn validate_config_path(config_path: &str) -> Result<()> {
+    let allowed = AllowedCorePaths::resolve()?;
+    let canonical = canonical_file(config_path, "core config")?;
+    // 配置必须位于 mihomo home 内，否则重载会被 mihomo 的 SAFE_PATHS 拒绝
+    if !canonical.starts_with(&allowed.core_dir) {
         return Err(anyhow!("Core config path is outside the allowed area"));
     }
 
@@ -281,7 +426,6 @@ fn validate_start_request(request: &StartCoreRequest) -> Result<()> {
 
 struct AllowedCorePaths {
     core_dir: PathBuf,
-    runtime_dir: PathBuf,
     mihomo_path: PathBuf,
 }
 
@@ -292,17 +436,12 @@ impl AllowedCorePaths {
             .join("core")
             .canonicalize()
             .context("Core directory does not exist")?;
-        let runtime_dir = data_root
-            .join("runtime")
-            .canonicalize()
-            .context("Runtime config directory does not exist")?;
         let mihomo_path = core_dir
             .join(core_binary_name())
             .canonicalize()
             .context("Core executable does not exist")?;
         Ok(Self {
             core_dir,
-            runtime_dir,
             mihomo_path,
         })
     }

--- a/native/service/src/installer.rs
+++ b/native/service/src/installer.rs
@@ -205,6 +205,24 @@ pub fn stop_core() -> Result<()> {
     }
 }
 
+pub fn apply_core_config_from_stdin() -> Result<()> {
+    let mut payload = String::new();
+    std::io::stdin()
+        .read_to_string(&mut payload)
+        .context("Failed to read core config parameters")?;
+    let command: ServiceCommand =
+        serde_json::from_str(&payload).context("Failed to parse core config parameters")?;
+
+    match send_service_command(command, Duration::from_secs(30))? {
+        ServiceResponse::CoreConfigApplied { mode, pid } => {
+            // stdout 格式与应用侧约定：mode=<reload|restart> pid=<n>
+            println!("mode={mode} pid={pid}");
+            Ok(())
+        }
+        other => bail!("Unexpected core apply response: {other:?}"),
+    }
+}
+
 pub fn restart_core() -> Result<()> {
     match send_service_command(ServiceCommand::RestartCore, Duration::from_secs(15))? {
         ServiceResponse::Success { message } => {

--- a/native/service/src/ipc.rs
+++ b/native/service/src/ipc.rs
@@ -10,6 +10,7 @@ use crate::core::{CoreManager, CoreState, StartCoreRequest};
 use crate::logging;
 use crate::protocol::{ServiceCommand, ServiceResponse};
 use crate::service_version;
+use hub::infra::core_api::ApiError;
 
 const MAX_REQUEST_BYTES: usize = 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
@@ -63,6 +64,28 @@ impl ServiceState {
                         code: "core.start_failed".to_string(),
                         message: error.to_string(),
                     },
+                }
+            }
+            ServiceCommand::ApplyCoreConfig { config_path } => {
+                match self.core.apply_config(config_path).await {
+                    Ok(outcome) => ServiceResponse::CoreConfigApplied {
+                        mode: outcome.mode.to_string(),
+                        pid: outcome.pid,
+                    },
+                    Err(error) => {
+                        // 4xx 拒绝不可回退重启；错误码随回执文本透传，便于日志定位
+                        let rejected = error
+                            .downcast_ref::<ApiError>()
+                            .is_some_and(|api| matches!(api, ApiError::ConfigRejected(_)));
+                        ServiceResponse::Error {
+                            code: if rejected {
+                                "core.config_rejected".to_string()
+                            } else {
+                                "core.apply_failed".to_string()
+                            },
+                            message: format!("{error:#}"),
+                        }
+                    }
                 }
             }
             ServiceCommand::StopCore => match self.core.stop().await {

--- a/native/service/src/lib.rs
+++ b/native/service/src/lib.rs
@@ -14,24 +14,25 @@ use anyhow::{Result, bail};
 
 const HELP_COMMANDS: &str = "\
 Commands:
-  foreground       Run the service in the foreground
-  install          Install and start the system service
-  uninstall        Stop and uninstall the system service
-  start            Start the system service
-  stop             Stop the system service
-  status           Print service status
-  heartbeat        Send a client heartbeat
-  start-core       Read startup parameters from stdin and start the core
-  stop-core        Stop the core hosted by the service
-  restart-core     Restart the core hosted by the service
-  shutdown         Ask the service to exit
-  logs [lines]     Print service logs
-  version          Print version
-  help             Print help
+  foreground           Run the service in the foreground
+  install              Install and start the system service
+  uninstall            Stop and uninstall the system service
+  start                Start the system service
+  stop                 Stop the system service
+  status               Print service status
+  heartbeat            Send a client heartbeat
+  start-core           Read startup parameters from stdin and start the core
+  apply-core-config    Read the config path from stdin and apply the core config
+  stop-core            Stop the core hosted by the service
+  restart-core         Restart the core hosted by the service
+  shutdown             Ask the service to exit
+  logs [lines]         Print service logs
+  version              Print version
+  help                 Print help
 
 Options:
-  -h, --help       Print help
-  -v, --version    Print version";
+  -h, --help           Print help
+  -v, --version        Print version";
 
 pub fn run() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -51,6 +52,7 @@ pub fn run() -> Result<()> {
         Some("status") => installer::print_status(),
         Some("heartbeat") => installer::heartbeat(),
         Some("start-core") => installer::start_core_from_stdin(),
+        Some("apply-core-config") => installer::apply_core_config_from_stdin(),
         Some("stop-core") => installer::stop_core(),
         Some("restart-core") => installer::restart_core(),
         Some("shutdown") => installer::shutdown(),

--- a/native/service/src/protocol.rs
+++ b/native/service/src/protocol.rs
@@ -13,6 +13,9 @@ pub enum ServiceCommand {
         config_path: String,
         data_core_dir: String,
     },
+    ApplyCoreConfig {
+        config_path: String,
+    },
     StopCore,
     RestartCore,
     Shutdown,
@@ -41,4 +44,8 @@ pub enum ServiceResponse {
         lines: Vec<String>,
     },
     HeartbeatAck,
+    CoreConfigApplied {
+        mode: String,
+        pid: u32,
+    },
 }

--- a/src/Stelliberty.Application/Platform/AppRuntimeNames.cs
+++ b/src/Stelliberty.Application/Platform/AppRuntimeNames.cs
@@ -16,6 +16,11 @@ public static class AppRuntimeNames
 
     public static string ServiceName => $"{PascalIdentifier(AppMetadata.Name)}Service{DevSuffix}";
 
+    // 必须与 Rust native/service channel.rs 的 command_endpoint 逐字一致。
+    public static string ServiceCommandEndpoint => OperatingSystem.IsWindows()
+        ? $@"\\.\pipe\{FileToken(AppMetadata.Name)}_service{FileDevSuffix}"
+        : $"/tmp/{FileToken(AppMetadata.Name)}_service{FileDevSuffix}.sock";
+
     public static string ServiceBinaryName => OperatingSystem.IsWindows()
         ? $"{FileToken(AppMetadata.Name)}_service.exe"
         : $"{FileToken(AppMetadata.Name)}_service";

--- a/src/Stelliberty.Application/Platform/IServiceModeManager.cs
+++ b/src/Stelliberty.Application/Platform/IServiceModeManager.cs
@@ -16,6 +16,9 @@ public interface IServiceModeManager
 
     Task<ServiceModeOperationResult> StartCoreHostAsync(ServiceModeCoreHostRequest request, CancellationToken cancellationToken = default);
 
+    // 应用新配置；成功回执 message 格式为 mode=<reload|restart> pid=<n>
+    Task<ServiceModeOperationResult> ApplyCoreConfigAsync(string configPath, CancellationToken cancellationToken = default);
+
     Task<ServiceModeOperationResult> StopCoreHostAsync(CancellationToken cancellationToken = default);
 
     Task<ServiceModeOperationResult> RestartCoreHostAsync(CancellationToken cancellationToken = default);

--- a/src/Stelliberty.Application/Platform/IServiceModeManager.cs
+++ b/src/Stelliberty.Application/Platform/IServiceModeManager.cs
@@ -7,21 +7,9 @@ public interface IServiceModeManager
     // 安装态与版本：只在启动和用户操作时查，代价高。
     Task<ServiceModeStatus> GetStatusAsync(CancellationToken cancellationToken = default);
 
-    // 核心运行态：高频轮询走这条，失败返回未观测而非"核心已停"。
-    Task<CoreObservation> ObserveCoreAsync(CancellationToken cancellationToken = default);
-
     Task<ServiceModeOperationResult> InstallOrUpdateAsync(CancellationToken cancellationToken = default);
 
     Task<ServiceModeOperationResult> UninstallAsync(CancellationToken cancellationToken = default);
-
-    Task<ServiceModeOperationResult> StartCoreHostAsync(ServiceModeCoreHostRequest request, CancellationToken cancellationToken = default);
-
-    // 应用新配置；成功回执 message 格式为 mode=<reload|restart> pid=<n>
-    Task<ServiceModeOperationResult> ApplyCoreConfigAsync(string configPath, CancellationToken cancellationToken = default);
-
-    Task<ServiceModeOperationResult> StopCoreHostAsync(CancellationToken cancellationToken = default);
-
-    Task<ServiceModeOperationResult> RestartCoreHostAsync(CancellationToken cancellationToken = default);
 
     Task<ServiceModeOperationResult> SendHeartbeatAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Stelliberty.Application/Platform/IServiceModeManager.cs
+++ b/src/Stelliberty.Application/Platform/IServiceModeManager.cs
@@ -1,8 +1,14 @@
+using Stelliberty.Application.Runtime;
+
 namespace Stelliberty.Application.Platform;
 
 public interface IServiceModeManager
 {
+    // 安装态与版本：只在启动和用户操作时查，代价高。
     Task<ServiceModeStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+
+    // 核心运行态：高频轮询走这条，失败返回未观测而非"核心已停"。
+    Task<CoreObservation> ObserveCoreAsync(CancellationToken cancellationToken = default);
 
     Task<ServiceModeOperationResult> InstallOrUpdateAsync(CancellationToken cancellationToken = default);
 

--- a/src/Stelliberty.Application/Platform/ServiceModeCoreHostRequest.cs
+++ b/src/Stelliberty.Application/Platform/ServiceModeCoreHostRequest.cs
@@ -1,6 +1,0 @@
-namespace Stelliberty.Application.Platform;
-
-public sealed record ServiceModeCoreHostRequest(
-    string CorePath,
-    string DataCoreDir,
-    string ConfigPath);

--- a/src/Stelliberty.Application/Proxies/ProxySelectionRestoringCoreManager.cs
+++ b/src/Stelliberty.Application/Proxies/ProxySelectionRestoringCoreManager.cs
@@ -14,7 +14,6 @@ public sealed class ProxySelectionRestoringCoreManager : ICoreManager, IDisposab
     private bool _hasObservedRunning;
     private bool _isManagedReset;
     private bool _hasPendingObservedReset;
-    private string? _pendingObservedSubscriptionId;
     private int? _lastRunningPid;
     private bool _isDisposed;
 
@@ -173,33 +172,18 @@ public sealed class ProxySelectionRestoringCoreManager : ICoreManager, IDisposab
         var shouldRestore = false;
         lock (_stateGate)
         {
-            if (!_isManagedReset)
+            // 只有核心实例换了才需要重下选择；状态跳变不代表换了核心。
+            var processChanged = !_isManagedReset
+                && _hasObservedRunning
+                && snapshot.State == CoreState.Running
+                && snapshot.Pid is not null
+                && snapshot.Pid != _lastRunningPid;
+            if (processChanged)
             {
-                if (snapshot.State != CoreState.Running && _hasObservedRunning)
-                {
-                    if (!_hasPendingObservedReset)
-                    {
-                        _pendingObservedSubscriptionId = _restorer.SuspendCoreSelectionImport("core-state-change");
-                        _hasPendingObservedReset = true;
-                    }
-                }
-                else if (snapshot.State == CoreState.Running)
-                {
-                    var processChanged = _hasObservedRunning
-                        && snapshot.Pid is not null
-                        && snapshot.Pid != _lastRunningPid;
-                    if (processChanged && !_hasPendingObservedReset)
-                    {
-                        _pendingObservedSubscriptionId = _restorer.SuspendCoreSelectionImport("core-process-change");
-                        _hasPendingObservedReset = true;
-                    }
-
-                    if (_hasPendingObservedReset)
-                    {
-                        subscriptionId = _pendingObservedSubscriptionId;
-                        shouldRestore = true;
-                    }
-                }
+                // 挂起与还原同处一个同步块，新核心的选择来不及被导入。
+                subscriptionId = _restorer.SuspendCoreSelectionImport("core-process-change");
+                _hasPendingObservedReset = true;
+                shouldRestore = true;
             }
 
             if (snapshot.State == CoreState.Running)
@@ -229,10 +213,9 @@ public sealed class ProxySelectionRestoringCoreManager : ICoreManager, IDisposab
                 }
 
                 _hasPendingObservedReset = false;
-                _pendingObservedSubscriptionId = null;
             }
 
-            await TryRestoreIfRunningAsync(subscriptionId, "core-state-recovery");
+            await TryRestoreIfRunningAsync(subscriptionId, "core-process-change");
         }
         finally
         {
@@ -253,7 +236,6 @@ public sealed class ProxySelectionRestoringCoreManager : ICoreManager, IDisposab
             if (isManagedReset)
             {
                 _hasPendingObservedReset = false;
-                _pendingObservedSubscriptionId = null;
             }
         }
     }

--- a/src/Stelliberty.Application/Runtime/CoreApplyConfigRequest.cs
+++ b/src/Stelliberty.Application/Runtime/CoreApplyConfigRequest.cs
@@ -1,3 +1,1 @@
-namespace Stelliberty.Application.Runtime;
-
-public sealed record CoreApplyConfigRequest(string RuntimeYamlPath, string SubscriptionId);
+public sealed record CoreApplyConfigRequest(string RuntimeYamlContent, string SubscriptionId);

--- a/src/Stelliberty.Application/Runtime/CoreObservation.cs
+++ b/src/Stelliberty.Application/Runtime/CoreObservation.cs
@@ -1,0 +1,33 @@
+namespace Stelliberty.Application.Runtime;
+
+// 区分"核心确实处于某状态"和"这次没看到核心"：后者不得当作状态变化，否则会被误判成重启。
+public sealed record CoreObservation
+{
+    private CoreObservation(CoreState? state, int? pid, string? lastError, string? unobservedReason)
+    {
+        State = state;
+        Pid = pid;
+        LastError = lastError;
+        UnobservedReason = unobservedReason;
+    }
+
+    public CoreState? State { get; }
+
+    public int? Pid { get; }
+
+    public string? LastError { get; }
+
+    public string? UnobservedReason { get; }
+
+    public bool IsObserved => State is not null;
+
+    public static CoreObservation Observed(CoreState state, int? pid, string? lastError)
+    {
+        return new CoreObservation(state, pid, lastError, null);
+    }
+
+    public static CoreObservation Unobserved(string reason)
+    {
+        return new CoreObservation(null, null, null, reason);
+    }
+}

--- a/src/Stelliberty.Application/Subscriptions/ISelectedSubscriptionRuntimeStore.cs
+++ b/src/Stelliberty.Application/Subscriptions/ISelectedSubscriptionRuntimeStore.cs
@@ -3,9 +3,10 @@ namespace Stelliberty.Application.Subscriptions;
 
 public interface ISelectedSubscriptionRuntimeStore
 {
-    SelectedSubscriptionRuntimePaths Save(Subscription subscription, string originalContent, string runtimeConfigContent);
+    // 持久化订阅原文与运行时配置，供调试查看与后续读取；跨层只传内容。
+    void Save(Subscription subscription, string originalContent, string runtimeConfigContent);
 
-    string SaveEmpty(string runtimeConfigContent);
+    void SaveEmpty(string runtimeConfigContent);
 
     string ReadRuntimeConfig(string subscriptionId);
 

--- a/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimeGenerator.cs
+++ b/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimeGenerator.cs
@@ -38,13 +38,11 @@ public sealed class SelectedSubscriptionRuntimeGenerator(
             RuntimeParams: request.RuntimeParams,
             // 自定义规则最后定稿，避免订阅覆写改写用户编辑结果。
             PostOverrideTransform: content => ApplyRuntimeRuleOverrides(subscription.Id, content)));
-        var paths = runtimeStore?.Save(subscription, originalContent, runtimeConfig.RuntimeConfigContent);
+        runtimeStore?.Save(subscription, originalContent, runtimeConfig.RuntimeConfigContent);
 
         return new SelectedSubscriptionRuntimeResult(
             subscription,
-            runtimeConfig.RuntimeConfigContent,
-            paths?.OriginalContentPath,
-            paths?.RuntimeConfigPath);
+            runtimeConfig.RuntimeConfigContent);
     }
 
     private string ReadOriginalContent(Subscription subscription)

--- a/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimePaths.cs
+++ b/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimePaths.cs
@@ -1,4 +1,0 @@
-using Stelliberty.Domain.Subscriptions;
-namespace Stelliberty.Application.Subscriptions;
-
-public sealed record SelectedSubscriptionRuntimePaths(string OriginalContentPath, string RuntimeConfigPath);

--- a/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimeResult.cs
+++ b/src/Stelliberty.Application/Subscriptions/SelectedSubscriptionRuntimeResult.cs
@@ -1,10 +1,7 @@
 using Stelliberty.Domain.Subscriptions;
-using Stelliberty.Application.Runtime;
 
 namespace Stelliberty.Application.Subscriptions;
 
 public sealed record SelectedSubscriptionRuntimeResult(
     Subscription Subscription,
-    string RuntimeConfigContent,
-    string? OriginalContentPath = null,
-    string? RuntimeConfigPath = null);
+    string RuntimeConfigContent);

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -403,6 +403,11 @@ public sealed partial class App : Avalonia.Application
             }
             else
             {
+                // --minimized：启动即最小化（调试拉起、开机自启）；静默启动优先级更高。
+                if (IsStartMinimizedRequested(desktop))
+                {
+                    mainWindow.WindowState = WindowState.Minimized;
+                }
                 desktop.MainWindow = mainWindow;
             }
 
@@ -484,6 +489,11 @@ public sealed partial class App : Avalonia.Application
     private static bool ShouldStartHidden(AppSettings settings)
     {
         return settings.IsSilentStartEnabled;
+    }
+
+    private static bool IsStartMinimizedRequested(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        return desktop.Args?.Contains("--minimized", StringComparer.OrdinalIgnoreCase) == true;
     }
 
     private void StopBackgroundServices()

--- a/src/Stelliberty.Desktop/App.axaml.cs
+++ b/src/Stelliberty.Desktop/App.axaml.cs
@@ -94,7 +94,7 @@ public sealed partial class App : Avalonia.Application
             ISystemProxyService systemProxyService = CreateSystemProxyService(
                 systemProxyPlatform,
                 platformDirectories.AppDataDirectory);
-            IServiceModeManager serviceModeManager = new DesktopServiceModeManager();
+            var serviceModeManager = new DesktopServiceModeManager();
             var coreProcessCleaner = new CoreProcessCleaner();
             var networkConnectionProbe = new SystemNetworkConnectionProbe();
             var processPrivilegeProbe = new SystemProcessPrivilegeProbe();
@@ -538,7 +538,7 @@ public sealed partial class App : Avalonia.Application
 
     private async Task StartCoreServicesAsync(
         ServiceModeStatus initialServiceModeStatus,
-        IServiceModeManager serviceModeManager,
+        DesktopServiceModeManager serviceModeManager,
         CoreProcessCleaner coreProcessCleaner,
         SwitchableCoreManager coreManager,
         MainWindowViewModel viewModel,
@@ -608,7 +608,7 @@ public sealed partial class App : Avalonia.Application
 
     private async Task<BootstrapResult> StartCoreHostAsync(
         ServiceModeStatus initialServiceModeStatus,
-        IServiceModeManager serviceModeManager,
+        DesktopServiceModeManager serviceModeManager,
         CoreProcessCleaner coreProcessCleaner,
         CancellationToken cancellationToken)
     {
@@ -721,7 +721,7 @@ public sealed partial class App : Avalonia.Application
     }
 #endif
 
-    private ICoreManager CreateCoreManager(ServiceModeStatus initialServiceModeStatus, IServiceModeManager serviceModeManager)
+    private ICoreManager CreateCoreManager(ServiceModeStatus initialServiceModeStatus, DesktopServiceModeManager serviceModeManager)
     {
         if (initialServiceModeStatus.IsRunning)
         {

--- a/src/Stelliberty.Desktop/HubStartupCoordinator.cs
+++ b/src/Stelliberty.Desktop/HubStartupCoordinator.cs
@@ -87,8 +87,9 @@ internal static class HubStartupCoordinator
 
     public static string WriteServiceModeActiveConfig(string content)
     {
-        Directory.CreateDirectory(DesktopApplicationLayout.RuntimeDirectory);
-        var path = Path.Combine(DesktopApplicationLayout.RuntimeDirectory, "_service_active.yaml");
+        // active 配置必须位于 mihomo home 内，否则重载会被 mihomo 的 SAFE_PATHS 拒绝
+        Directory.CreateDirectory(DesktopApplicationLayout.CoreDirectory);
+        var path = Path.Combine(DesktopApplicationLayout.CoreDirectory, "_service_active.yaml");
         File.WriteAllText(path, InjectCorePipe(content));
         return path;
     }

--- a/src/Stelliberty.Desktop/HubStartupCoordinator.cs
+++ b/src/Stelliberty.Desktop/HubStartupCoordinator.cs
@@ -74,9 +74,9 @@ internal static class HubStartupCoordinator
     public static ServiceModeCoreHostRequest CreateServiceModeCoreHostRequest()
     {
         return new ServiceModeCoreHostRequest(
-            DesktopApplicationLayout.CoreBinaryPath,
-            DesktopApplicationLayout.CoreDirectory,
-            BuildInitialServiceModeConfigPath());
+            CorePath: DesktopApplicationLayout.CoreBinaryPath,
+            DataCoreDir: DesktopApplicationLayout.CoreDirectory,
+            ConfigPath: BuildInitialServiceModeConfigPath());
     }
 
     public static string BuildInitialServiceModeConfigPath()

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using Microsoft.Win32;
 using Stelliberty.Application.Diagnostics;
 using Stelliberty.Application.Platform;
+using Stelliberty.Application.Runtime;
 
 namespace Stelliberty.Desktop.Services;
 
@@ -15,6 +16,8 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
 {
     // 管理超时覆盖提权和服务操作；Rust IPC 超时只约束一次本地调用。
     private static readonly TimeSpan StatusTimeout = TimeSpan.FromSeconds(5);
+    // 远短于 2s 轮询间隔避免请求堆叠
+    private static readonly TimeSpan ObserveTimeout = TimeSpan.FromMilliseconds(800);
     private static readonly TimeSpan ManageTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan StatusSettleTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan StatusPollInterval = TimeSpan.FromMilliseconds(250);
@@ -24,6 +27,33 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
     private DateTime _serviceVersionFileLastWriteUtc;
     private long _serviceVersionFileLength = -1;
     private string? _cachedServiceVersion;
+
+    public async Task<CoreObservation> ObserveCoreAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var payload = await ServiceCommandPipeClient
+                .RequestStatusAsync(ObserveTimeout, cancellationToken)
+                .ConfigureAwait(false);
+            if (!string.Equals(payload.ServiceName, AppRuntimeNames.ServiceName, StringComparison.Ordinal))
+            {
+                return CoreObservation.Unobserved($"service name does not match: {payload.ServiceName}");
+            }
+
+            return CoreObservation.Observed(
+                ParseCoreState(payload.CoreState),
+                payload.CorePid,
+                payload.CoreLastError);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return CoreObservation.Unobserved(DescribeObserveFailure(exception));
+        }
+    }
 
     public async Task<ServiceModeStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
@@ -303,6 +333,26 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
             AppLogger.Error(exception, failure);
             return ServiceModeOperationResult.Failed($"{failure}: {exception.Message}");
         }
+    }
+
+    private static CoreState ParseCoreState(string? value)
+    {
+        return value switch
+        {
+            "running" => CoreState.Running,
+            "stopping" => CoreState.Stopping,
+            "stopped" => CoreState.Stopped,
+            "crashed" => CoreState.Crashed,
+            // 服务报了个本版本不认识的状态，属于观测不到而非核心异常。
+            _ => CoreState.Unavailable,
+        };
+    }
+
+    private static string DescribeObserveFailure(Exception exception)
+    {
+        return exception is OperationCanceledException
+            ? "service pipe request timed out"
+            : $"{exception.GetType().Name}: {exception.Message}";
     }
 
     private static string? InstalledServiceBinaryPath()

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -214,13 +214,23 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
 
     public Task<ServiceModeOperationResult> StartCoreHostAsync(ServiceModeCoreHostRequest request, CancellationToken cancellationToken = default)
     {
-        var payload = JsonSerializer.Serialize(
+        return RunServiceCommandAsync("start-core", false, ManageTimeout, cancellationToken, SerializeStartCorePayload(request));
+    }
+
+    public Task<ServiceModeOperationResult> ApplyCoreConfigAsync(string configPath, CancellationToken cancellationToken = default)
+    {
+        var payload = JsonSerializer.Serialize(new ApplyCoreConfigCommand(new ApplyCoreConfigPayload(configPath)));
+        return RunServiceCommandAsync("apply-core-config", false, ManageTimeout, cancellationToken, payload);
+    }
+
+    private static string SerializeStartCorePayload(ServiceModeCoreHostRequest request)
+    {
+        return JsonSerializer.Serialize(
             new StartCoreCommand(
                 new StartCorePayload(
                     request.CorePath,
                     request.ConfigPath,
                     request.DataCoreDir)));
-        return RunServiceCommandAsync("start-core", false, ManageTimeout, cancellationToken, payload);
     }
 
     public Task<ServiceModeOperationResult> StopCoreHostAsync(CancellationToken cancellationToken = default)
@@ -543,7 +553,7 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            RedirectStandardInput = command == "start-core",
+            RedirectStandardInput = command is "start-core" or "apply-core-config",
             CreateNoWindow = true,
             // 服务端输出 UTF-8；Windows 默认按 ANSI 解码会把中文系统错误变成乱码。
             StandardOutputEncoding = Encoding.UTF8,
@@ -735,6 +745,7 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         return "\"" + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
     }
 
+    // 服务 spawn 核心所需的完整启动参数
     private sealed record StartCoreCommand(
         [property: JsonPropertyName("data")] StartCorePayload Data)
     {
@@ -742,9 +753,18 @@ internal sealed class DesktopServiceModeManager : IServiceModeManager
         public string Type => "StartCore";
     }
 
-    // 服务协议字段保留 mihomo_path，兼容已安装的旧服务。
     private sealed record StartCorePayload(
         [property: JsonPropertyName("mihomo_path")] string CorePath,
         [property: JsonPropertyName("config_path")] string ConfigPath,
         [property: JsonPropertyName("data_core_dir")] string DataCoreDir);
+
+    private sealed record ApplyCoreConfigCommand(
+        [property: JsonPropertyName("data")] ApplyCoreConfigPayload Data)
+    {
+        [JsonPropertyName("type")]
+        public string Type => "ApplyCoreConfig";
+    }
+
+    private sealed record ApplyCoreConfigPayload(
+        [property: JsonPropertyName("config_path")] string ConfigPath);
 }

--- a/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
+++ b/src/Stelliberty.Desktop/Services/DesktopServiceModeManager.cs
@@ -14,9 +14,9 @@ namespace Stelliberty.Desktop.Services;
 
 internal sealed class DesktopServiceModeManager : IServiceModeManager
 {
-    // 管理超时覆盖提权和服务操作；Rust IPC 超时只约束一次本地调用。
+    // 覆盖 status、heartbeat、version 这类非提权只读查询；提权与生命周期操作用 ManageTimeout。
     private static readonly TimeSpan StatusTimeout = TimeSpan.FromSeconds(5);
-    // 远短于 2s 轮询间隔避免请求堆叠
+    // 远短于 2s 轮询间隔，避免请求堆叠。
     private static readonly TimeSpan ObserveTimeout = TimeSpan.FromMilliseconds(800);
     private static readonly TimeSpan ManageTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan StatusSettleTimeout = TimeSpan.FromSeconds(10);

--- a/src/Stelliberty.Desktop/Services/ServiceCommandPipeClient.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceCommandPipeClient.cs
@@ -1,0 +1,105 @@
+using System.IO.Pipes;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Stelliberty.Application.Platform;
+
+namespace Stelliberty.Desktop.Services;
+
+// 直连服务命令管道，帧格式与 Rust native/service ipc.rs 一致：4 字节小端长度 + UTF-8 JSON。
+internal static class ServiceCommandPipeClient
+{
+    // 必须与 Rust native/service/src/ipc.rs MAX_RESPONSE_BYTES 一致
+    private const int MaxResponseBytes = 1024 * 1024;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    public static async Task<ServiceStatusPayload> RequestStatusAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+        await using var stream = await ConnectAsync(cts.Token).ConfigureAwait(false);
+        // 服务每个连接只处理一条命令，写完即读。
+        await WriteFrameAsync(stream, """{"type":"Status"}""", cts.Token).ConfigureAwait(false);
+        var payload = await ReadFrameAsync(stream, cts.Token).ConfigureAwait(false);
+        var envelope = JsonSerializer.Deserialize<ServiceResponseEnvelope>(payload, SerializerOptions)
+            ?? throw new InvalidDataException("Service status response is empty.");
+
+        if (envelope.Type != "Status")
+        {
+            throw new InvalidDataException($"Unexpected service response: {envelope.Type}");
+        }
+
+        return envelope.Data.Deserialize<ServiceStatusPayload>(SerializerOptions)
+            ?? throw new InvalidDataException("Service status payload is empty.");
+    }
+
+    private static async Task<Stream> ConnectAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = AppRuntimeNames.ServiceCommandEndpoint;
+        if (OperatingSystem.IsWindows())
+        {
+            // NamedPipeClientStream 只接受管道名，ServiceCommandEndpoint 已带 \\.\pipe\ 前缀需剥离
+            var pipeName = endpoint[@"\\.\pipe\".Length..];
+            var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            try
+            {
+                await pipe.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                return pipe;
+            }
+            catch
+            {
+                await pipe.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        await socket.ConnectAsync(new UnixDomainSocketEndPoint(endpoint), cancellationToken).ConfigureAwait(false);
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+
+    private static async Task WriteFrameAsync(Stream stream, string json, CancellationToken cancellationToken)
+    {
+        var payload = Encoding.UTF8.GetBytes(json);
+        var header = BitConverter.GetBytes((uint)payload.Length);
+        if (!BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(header);
+        }
+
+        await stream.WriteAsync(header, cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var header = new byte[4];
+        await stream.ReadExactlyAsync(header, cancellationToken).ConfigureAwait(false);
+        if (!BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(header);
+        }
+
+        var length = BitConverter.ToUInt32(header);
+        if (length > MaxResponseBytes)
+        {
+            throw new InvalidDataException($"Service response frame is too large: {length}");
+        }
+
+        var payload = new byte[length];
+        await stream.ReadExactlyAsync(payload, cancellationToken).ConfigureAwait(false);
+        return payload;
+    }
+
+    private sealed record ServiceResponseEnvelope(
+        [property: JsonPropertyName("type")] string Type,
+        [property: JsonPropertyName("data")] JsonElement Data);
+}

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreHostRequest.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreHostRequest.cs
@@ -1,0 +1,7 @@
+namespace Stelliberty.Desktop.Services;
+
+// 服务进程 spawn mihomo 所需的启动参数，仅供 Desktop 层核心管理使用
+public sealed record ServiceModeCoreHostRequest(
+    string CorePath,
+    string DataCoreDir,
+    string ConfigPath);

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -80,6 +80,39 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     {
         ThrowIfDisposed();
         var activePath = _writeActiveConfig(await File.ReadAllTextAsync(request.RuntimeYamlPath, cancellationToken).ConfigureAwait(false));
+
+        // 核心未运行时服务侧没有可回填的启动参数，直接走完整启动
+        CoreSnapshot? snapshot;
+        lock (_snapshotGate)
+        {
+            snapshot = _lastSnapshot;
+        }
+
+        if (snapshot is not { State: CoreState.Running })
+        {
+            return await StartCoreHostAsync(activePath, cancellationToken).ConfigureAwait(false);
+        }
+
+        var result = await _serviceModeManager.ApplyCoreConfigAsync(activePath, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            throw new InvalidOperationException(result.Message);
+        }
+
+        if (TryParseReloadOutcome(result.Message, out var reloadPid))
+        {
+            // 重载进程未变，日志流与状态监视器保持运行
+            AppLogger.Info($"Service-mode core config reloaded: pid={reloadPid}");
+            return new CoreApplyConfigResult(CoreApplyMode.Reload, reloadPid);
+        }
+
+        // 回执格式漂移时按重启处理并记录原文，避免静默误判
+        AppLogger.Warning($"Unexpected core apply receipt: {result.Message}");
+        return await WaitCoreHostReadyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CoreApplyConfigResult> StartCoreHostAsync(string activePath, CancellationToken cancellationToken)
+    {
         var serviceRequest = new ServiceModeCoreHostRequest(
             DesktopApplicationLayout.CoreBinaryPath,
             DesktopApplicationLayout.CoreDirectory,
@@ -90,11 +123,29 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
             throw new InvalidOperationException(result.Message);
         }
 
+        return await WaitCoreHostReadyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CoreApplyConfigResult> WaitCoreHostReadyAsync(CancellationToken cancellationToken)
+    {
         var pid = await WaitReadyAsync(cancellationToken).ConfigureAwait(false);
         _logStreamer.Restart();
         StartStatusMonitor();
         PublishState(CoreState.Running, pid, null);
         return new CoreApplyConfigResult(CoreApplyMode.Restart, pid);
+    }
+
+    // 服务侧回执格式固定：mode=reload pid=<n>
+    private static bool TryParseReloadOutcome(string message, out int pid)
+    {
+        const string prefix = "mode=reload pid=";
+        if (!message.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            pid = 0;
+            return false;
+        }
+
+        return int.TryParse(message.AsSpan(prefix.Length), out pid);
     }
 
     public async Task RestartAsync(CancellationToken cancellationToken = default)

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -20,6 +20,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     private readonly Func<string, string> _writeActiveConfig;
     private readonly Action<bool> _setCoreHostActive;
     private readonly object _monitorGate = new();
+    private readonly object _snapshotGate = new();
     private CancellationTokenSource? _monitorCancellation;
     private Task? _monitorTask;
     private CoreSnapshot? _lastSnapshot;
@@ -60,10 +61,8 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     public async Task<CoreSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        var status = await _serviceModeManager.GetStatusAsync(cancellationToken).ConfigureAwait(false);
-        var snapshot = ToSnapshot(status);
-        PublishSnapshot(snapshot);
-        return snapshot;
+        var observation = await _serviceModeManager.ObserveCoreAsync(cancellationToken).ConfigureAwait(false);
+        return ApplyObservation(observation);
     }
 
     public async Task EnsureReadyAsync(CancellationToken cancellationToken = default)
@@ -185,17 +184,72 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
             try
             {
                 await Task.Delay(StatePollInterval, cancellationToken).ConfigureAwait(false);
-                var status = await _serviceModeManager.GetStatusAsync(cancellationToken).ConfigureAwait(false);
-                PublishSnapshot(ToSnapshot(status));
+                var observation = await _serviceModeManager.ObserveCoreAsync(cancellationToken).ConfigureAwait(false);
+                ApplyObservation(observation);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 return;
             }
-            catch (Exception exception)
-            {
-                PublishSnapshot(new CoreSnapshot(CoreState.Unavailable, null, HubStartupCoordinator.CorePipe, exception.Message));
-            }
+        }
+    }
+
+    // 观测失败不等于核心停了；只有确认核心进程已消失才降级为不可用。
+    private CoreSnapshot ApplyObservation(CoreObservation observation)
+    {
+        if (observation.IsObserved)
+        {
+            var snapshot = new CoreSnapshot(
+                observation.State!.Value,
+                observation.Pid,
+                HubStartupCoordinator.CorePipe,
+                observation.LastError);
+            PublishSnapshot(snapshot);
+            return snapshot;
+        }
+
+        CoreSnapshot? lastSnapshot;
+        lock (_snapshotGate)
+        {
+            lastSnapshot = _lastSnapshot;
+        }
+
+        if (lastSnapshot is not null && IsCoreProcessAlive(lastSnapshot.Pid))
+        {
+            // 核心进程仍在则保留上次状态，不清日志页也不重下代理选择。
+            AppLogger.Debug($"Service-mode core observation skipped: reason={observation.UnobservedReason} pid={lastSnapshot.Pid}");
+            return lastSnapshot;
+        }
+
+        var unavailable = new CoreSnapshot(
+            CoreState.Unavailable,
+            null,
+            HubStartupCoordinator.CorePipe,
+            observation.UnobservedReason);
+        PublishSnapshot(unavailable);
+        return unavailable;
+    }
+
+    // 核心被服务的 Job 对象绑定，宿主消失核心必消失；进程名兜住 PID 复用。
+    private static bool IsCoreProcessAlive(int? pid)
+    {
+        if (pid is not > 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(pid.Value);
+            var processName = process.ProcessName;
+            return string.Equals(
+                processName,
+                Path.GetFileNameWithoutExtension(DesktopApplicationLayout.CoreBinaryPath),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            return false;
         }
     }
 
@@ -204,14 +258,12 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         var stopwatch = Stopwatch.StartNew();
         while (stopwatch.Elapsed < ReadyTimeout)
         {
-            var status = await _serviceModeManager.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+            var observation = await _serviceModeManager.ObserveCoreAsync(cancellationToken).ConfigureAwait(false);
             // 服务上报的进程号用于确认管道响应来自服务核心。
-            if (status.IsRunning
-                && status.CoreState == "running"
-                && status.CorePid is > 0
+            if (observation is { State: CoreState.Running, Pid: > 0 }
                 && !string.IsNullOrWhiteSpace(await ProbeVersionAsync(cancellationToken).ConfigureAwait(false)))
             {
-                return status.CorePid.Value;
+                return observation.Pid.Value;
             }
 
             await Task.Delay(ReadyPollInterval, cancellationToken).ConfigureAwait(false);
@@ -233,9 +285,9 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
             return;
         }
 
+        // 日志流可能在快照未变期间断开，故每次发布都重建，不能并入去重分支。
         if (snapshot.State == CoreState.Running)
         {
-            // 状态查询恢复后必须重新建立先前停止的日志流。
             _logStreamer.Start();
         }
         else
@@ -244,13 +296,20 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         }
 
         _setCoreHostActive(snapshot.State == CoreState.Running);
-        if (_lastSnapshot == snapshot)
+
+        CoreSnapshot? previous;
+        lock (_snapshotGate)
         {
-            return;
+            if (_lastSnapshot == snapshot)
+            {
+                return;
+            }
+
+            previous = _lastSnapshot;
+            _lastSnapshot = snapshot;
         }
 
-        LogStateTransition(_lastSnapshot, snapshot);
-        _lastSnapshot = snapshot;
+        LogStateTransition(previous, snapshot);
         StateChanged?.Invoke(this, snapshot);
     }
 
@@ -297,24 +356,4 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         ObjectDisposedException.ThrowIf(_isDisposed, this);
     }
 
-    private static CoreState ParseCoreState(string? value)
-    {
-        return value switch
-        {
-            "running" => CoreState.Running,
-            "stopping" => CoreState.Stopping,
-            "stopped" => CoreState.Stopped,
-            "crashed" => CoreState.Crashed,
-            _ => CoreState.Unavailable,
-        };
-    }
-
-    private static CoreSnapshot ToSnapshot(ServiceModeStatus status)
-    {
-        return new CoreSnapshot(
-            ParseCoreState(status.CoreState),
-            status.CorePid,
-            HubStartupCoordinator.CorePipe,
-            status.CoreLastError);
-    }
 }

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -13,6 +13,8 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     private static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(12);
     private static readonly TimeSpan ReadyPollInterval = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan StatePollInterval = TimeSpan.FromSeconds(2);
+    // 覆盖一次观测往返（800ms）留足余量；超时则放弃等待，不阻塞进程退出。
+    private static readonly TimeSpan MonitorExitTimeout = TimeSpan.FromSeconds(3);
 
     private readonly IServiceModeManager _serviceModeManager;
     private readonly HttpClient _coreClient;
@@ -52,7 +54,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         }
 
         _isDisposed = true;
-        StopStatusMonitor();
+        StopStatusMonitor(waitForExit: true);
         _logStreamer.MessageReceived -= OnLogMessageReceived;
         _logStreamer.Dispose();
         _coreClient.Dispose();
@@ -131,7 +133,8 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         }
     }
 
-    private void StopStatusMonitor()
+    // waitForExit 仅用于释放路径：轮询任务持有 _coreClient，必须等它退出后才能释放。
+    private void StopStatusMonitor(bool waitForExit = false)
     {
         CancellationTokenSource? cancellation;
         Task? task;
@@ -149,6 +152,19 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
         }
 
         cancellation.Cancel();
+        if (waitForExit && task is not null)
+        {
+            // 轮询全程 ConfigureAwait(false)，同步等待不会死锁；取消后至多等一个观测往返。
+            try
+            {
+                task.Wait(MonitorExitTimeout);
+            }
+            catch (AggregateException)
+            {
+                // 轮询自身异常在循环内已记录，释放路径无需再处理。
+            }
+        }
+
         DisposeCancellationAfterTask(cancellation, task);
     }
 
@@ -345,7 +361,8 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
                 ? version.GetString()
                 : null;
         }
-        catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException or JsonException or IOException)
+        // 等待轮询退出有超时上限，超时后客户端可能已在释放路径中关闭。
+        catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException or JsonException or IOException or ObjectDisposedException)
         {
             return null;
         }

--- a/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeCoreManager.cs
@@ -16,7 +16,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     // 覆盖一次观测往返（800ms）留足余量；超时则放弃等待，不阻塞进程退出。
     private static readonly TimeSpan MonitorExitTimeout = TimeSpan.FromSeconds(3);
 
-    private readonly IServiceModeManager _serviceModeManager;
+    private readonly DesktopServiceModeManager _serviceModeManager;
     private readonly HttpClient _coreClient;
     private readonly CorePipeLogStreamer _logStreamer;
     private readonly Func<string, string> _writeActiveConfig;
@@ -29,7 +29,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     private bool _isDisposed;
 
     public ServiceModeCoreManager(
-        IServiceModeManager serviceModeManager,
+        DesktopServiceModeManager serviceModeManager,
         string corePipe,
         Func<string, string> writeActiveConfig,
         Action<bool> setCoreHostActive)
@@ -79,7 +79,7 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     public async Task<CoreApplyConfigResult> ApplyConfigAsync(CoreApplyConfigRequest request, CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        var activePath = _writeActiveConfig(await File.ReadAllTextAsync(request.RuntimeYamlPath, cancellationToken).ConfigureAwait(false));
+        var activePath = _writeActiveConfig(request.RuntimeYamlContent);
 
         // 核心未运行时服务侧没有可回填的启动参数，直接走完整启动
         CoreSnapshot? snapshot;
@@ -114,9 +114,9 @@ internal sealed class ServiceModeCoreManager : ICoreManager, IDisposable
     private async Task<CoreApplyConfigResult> StartCoreHostAsync(string activePath, CancellationToken cancellationToken)
     {
         var serviceRequest = new ServiceModeCoreHostRequest(
-            DesktopApplicationLayout.CoreBinaryPath,
-            DesktopApplicationLayout.CoreDirectory,
-            activePath);
+            CorePath: DesktopApplicationLayout.CoreBinaryPath,
+            DataCoreDir: DesktopApplicationLayout.CoreDirectory,
+            ConfigPath: activePath);
         var result = await _serviceModeManager.StartCoreHostAsync(serviceRequest, cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccess)
         {

--- a/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceModeSessionSwitcher.cs
@@ -6,7 +6,7 @@ using Stelliberty.Native.Hub;
 namespace Stelliberty.Desktop.Services;
 
 internal sealed class ServiceModeSessionSwitcher(
-    IServiceModeManager serviceModeManager,
+    DesktopServiceModeManager serviceModeManager,
     SwitchableCoreManager coreManager,
     Func<ServiceModeStatus, ICoreManager> createServiceCoreManager,
     Func<ICoreManager> createNormalCoreManager,

--- a/src/Stelliberty.Desktop/Services/ServiceStatusPayload.cs
+++ b/src/Stelliberty.Desktop/Services/ServiceStatusPayload.cs
@@ -1,0 +1,8 @@
+namespace Stelliberty.Desktop.Services;
+
+// 服务命令管道 Status 响应的 data 段，字段名由 snake_case 策略映射；响应里其余字段无消费方，反序列化时忽略。
+internal sealed record ServiceStatusPayload(
+    string ServiceName,
+    string CoreState,
+    int? CorePid,
+    string? CoreLastError);

--- a/src/Stelliberty.Infrastructure/Core/IpcCoreManager.cs
+++ b/src/Stelliberty.Infrastructure/Core/IpcCoreManager.cs
@@ -82,7 +82,7 @@ public sealed class IpcCoreManager : ICoreManager, IDisposable, IAsyncDisposable
     {
         var paramJson = JsonSerializer.SerializeToElement(new
         {
-            runtime_yaml_path = request.RuntimeYamlPath,
+            runtime_yaml_content = request.RuntimeYamlContent,
             subscription_id = request.SubscriptionId,
         });
         var result = await _client.RequestAsync("core.apply_config", paramJson, cancellationToken).ConfigureAwait(false);

--- a/src/Stelliberty.Infrastructure/Runtime/FileRuntimeConfigStore.cs
+++ b/src/Stelliberty.Infrastructure/Runtime/FileRuntimeConfigStore.cs
@@ -8,29 +8,23 @@ public sealed class FileRuntimeConfigStore(string runtimeDirectory) : ISelectedS
 {
     private readonly string _runtimeDirectory = runtimeDirectory;
 
-    public SelectedSubscriptionRuntimePaths Save(Subscription subscription, string originalContent, string runtimeConfigContent)
+    public void Save(Subscription subscription, string originalContent, string runtimeConfigContent)
     {
         var subscriptionRuntimeDirectory = Path.Combine(_runtimeDirectory, subscription.Id);
         Directory.CreateDirectory(subscriptionRuntimeDirectory);
 
-        var originalContentPath = Path.Combine(subscriptionRuntimeDirectory, "original.yaml");
-        var runtimeConfigPath = Path.Combine(subscriptionRuntimeDirectory, "runtime.yaml");
-        File.WriteAllText(originalContentPath, originalContent);
-        File.WriteAllText(runtimeConfigPath, runtimeConfigContent);
+        File.WriteAllText(Path.Combine(subscriptionRuntimeDirectory, "original.yaml"), originalContent);
+        File.WriteAllText(Path.Combine(subscriptionRuntimeDirectory, "runtime.yaml"), runtimeConfigContent);
         AppLogger.Info($"Runtime config generated: {subscription.Name}");
-
-        return new SelectedSubscriptionRuntimePaths(originalContentPath, runtimeConfigPath);
     }
 
-    public string SaveEmpty(string runtimeConfigContent)
+    public void SaveEmpty(string runtimeConfigContent)
     {
         var emptyRuntimeDirectory = Path.Combine(_runtimeDirectory, "empty");
         Directory.CreateDirectory(emptyRuntimeDirectory);
 
-        var runtimeConfigPath = Path.Combine(emptyRuntimeDirectory, "runtime.yaml");
-        File.WriteAllText(runtimeConfigPath, runtimeConfigContent);
+        File.WriteAllText(Path.Combine(emptyRuntimeDirectory, "runtime.yaml"), runtimeConfigContent);
         AppLogger.Info("Empty runtime config generated");
-        return runtimeConfigPath;
     }
 
     public string ReadRuntimeConfig(string subscriptionId)

--- a/src/Stelliberty.Native/Hub/HubBootstrap.cs
+++ b/src/Stelliberty.Native/Hub/HubBootstrap.cs
@@ -71,9 +71,10 @@ public static class HubBootstrap
     {
         lock (Gate)
         {
+            // hub 未启动即普通核心必然未运行，停止视为已完成
             if (!_started)
             {
-                return BootstrapResult.Failure("Hub is not initialized.");
+                return BootstrapResult.Success("Normal-mode core is not running.");
             }
 
             try

--- a/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/Stelliberty.Presentation/ViewModels/MainWindowViewModel.cs
@@ -781,12 +781,12 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
             var shouldClearFailureNow = true;
             var wasAppliedToCore = false;
             var result = GenerateSelectedSubscriptionRuntimeWithOverrideFallback(subscriptionId, runtimeFallbackGenerator);
-            if (CoreManager is not null && !string.IsNullOrWhiteSpace(result.RuntimeConfigPath))
+            if (CoreManager is not null)
             {
                 // pending 只覆盖重启路径，重载成功后立即清除。
                 _pendingRuntimeSubscriptionId = subscriptionId;
                 var applyResult = await ApplyRuntimeConfigToCoreAsync(
-                    new CoreApplyConfigRequest(result.RuntimeConfigPath, subscriptionId),
+                    new CoreApplyConfigRequest(result.RuntimeConfigContent, subscriptionId),
                     refreshVersion,
                     endpointChangeVersion);
                 if (applyResult is null)
@@ -932,11 +932,11 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
     private async Task ApplyEmptyRuntimeToCoreAsync(int? refreshVersion = null, long endpointChangeVersion = 0)
     {
         var emptyConfig = _runtimeConfigGenerator.GenerateEmpty(CurrentRuntimeConfigParams());
-        var emptyConfigPath = _runtimeStore?.SaveEmpty(emptyConfig.RuntimeConfigContent);
-        if (CoreManager is not null && !string.IsNullOrWhiteSpace(emptyConfigPath))
+        _runtimeStore?.SaveEmpty(emptyConfig.RuntimeConfigContent);
+        if (CoreManager is not null)
         {
             var applyResult = await ApplyRuntimeConfigToCoreAsync(
-                new CoreApplyConfigRequest(emptyConfigPath, string.Empty),
+                new CoreApplyConfigRequest(emptyConfig.RuntimeConfigContent, string.Empty),
                 refreshVersion,
                 endpointChangeVersion);
             if (applyResult is null)


### PR DESCRIPTION
## Summary

Release v2.0.30. Service-mode core config changes now reload in place instead of restarting the core process, plus stability fixes for service-mode status polling and app shutdown, and a `--minimized` startup flag.

## Change Type

- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Other:

## Checklist

- [ ] Wrapped new or changed business logic in `src/Stelliberty.Desktop/Debug`
- [ ] Added `AutomationId` for new interactive controls
- [ ] Added or updated Pre-build Tests or Post-build Tests
- [x] Passed `python scripts/test.py --all`
- [x] Ran formatter (`dotnet format` / `cargo fmt`)

## Testing

- `python scripts/test.py --all` — 6/6 projects passed
- `python scripts/build.py --dev` — produced `stelliberty-v2.0.30-win-x64-dev`
- E2E on both modes: IPC mode reload keeps pid on config apply and restarts on RESTART_FIELDS change; service mode reload keeps pid (29524 stable) and restarts on restart-trigger fields (31236 -> 29524)
- Service install/uninstall full cycle verified via `cli.py service.install` / `service.uninstall`, normal-mode core resumed after uninstall

## Notes

- Service binary bumped to 1.0.2 so installed-service version checks can detect and prompt the update; old 1.0.1 services are not supported
- Runtime configs are now passed by content across layers, removing path leakage from the Application and Presentation boundaries
